### PR TITLE
Upgrade MiXCR software to 4.7.0-316-develop

### DIFF
--- a/.changeset/upgrade-mixcr-software.md
+++ b/.changeset/upgrade-mixcr-software.md
@@ -1,5 +1,5 @@
 ---
-'@platforma-open/milaboratories.mixcr-clonotyping.workflow': patch
+'@platforma-open/milaboratories.mixcr-clonotyping-2.workflow': patch
 ---
 
 Upgrade MiXCR software to 4.7.0-316-develop

--- a/.changeset/upgrade-mixcr-software.md
+++ b/.changeset/upgrade-mixcr-software.md
@@ -1,0 +1,5 @@
+---
+'@platforma-open/milaboratories.mixcr-clonotyping.workflow': patch
+---
+
+Upgrade MiXCR software to 4.7.0-316-develop

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -25,8 +25,8 @@ catalogs:
       specifier: ^1.11.2
       version: 1.11.2
     '@platforma-open/milaboratories.software-mixcr':
-      specifier: 4.7.0-302-develop
-      version: 4.7.0-302-develop
+      specifier: 4.7.0-316-develop
+      version: 4.7.0-316-develop
     '@platforma-sdk/block-tools':
       specifier: 2.6.68
       version: 2.6.68
@@ -266,7 +266,7 @@ importers:
     dependencies:
       '@platforma-open/milaboratories.software-mixcr':
         specifier: 'catalog:'
-        version: 4.7.0-302-develop
+        version: 4.7.0-316-develop
       '@platforma-sdk/workflow-tengo':
         specifier: 'catalog:'
         version: 5.9.0
@@ -1259,8 +1259,8 @@ packages:
   '@platforma-open/milaboratories.samples-and-data@1.12.3':
     resolution: {integrity: sha512-eb953z4hajvI4DmERvNU/86b1Rb/EDH/wq6tIF/Y/dElTopR1g787blvplDt1wpG2DBTrgylHiNozar4uoiMxg==}
 
-  '@platforma-open/milaboratories.software-mixcr@4.7.0-302-develop':
-    resolution: {integrity: sha512-O595tiq0/Ap8NiO7jpdN+N6P5Szpr4cUptkmvNN4knPprncgxxAobUrm7YQ5KxKzzJJCvVocpRs2QbWAu0azYQ==}
+  '@platforma-open/milaboratories.software-mixcr@4.7.0-316-develop':
+    resolution: {integrity: sha512-xkfN1gHPcwWs+QMgKLzqHi8rNlnP43v5teaXIJFjQw89l+uK/TczdeHlEo6CvkGuL7FJ/3w3ADaeWeS0GVKGdw==}
 
   '@platforma-open/milaboratories.software-ptabler.schema@1.12.5':
     resolution: {integrity: sha512-8KDVwfi00gqNU8r92XxecVleu/Jk5RoylwOMsoUatbkyTVL/+yQavdAgXc5aRLop07AvG3cFpHXW8ZqYBc7zbQ==}
@@ -6075,7 +6075,7 @@ snapshots:
       '@platforma-open/milaboratories.samples-and-data.workflow': 2.4.1
       '@platforma-sdk/model': 1.46.0
 
-  '@platforma-open/milaboratories.software-mixcr@4.7.0-302-develop': {}
+  '@platforma-open/milaboratories.software-mixcr@4.7.0-316-develop': {}
 
   '@platforma-open/milaboratories.software-ptabler.schema@1.12.5':
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -19,7 +19,7 @@ catalog:
   '@platforma-sdk/test': 1.58.7
   '@milaboratories/helpers': 1.13.5
 
-  '@platforma-open/milaboratories.software-mixcr': 4.7.0-302-develop
+  '@platforma-open/milaboratories.software-mixcr': 4.7.0-316-develop
 
   'vue': ^3.5.15
 


### PR DESCRIPTION
## Summary

- Upgrade `@platforma-open/milaboratories.software-mixcr` from `4.7.0-302-develop` to `4.7.0-316-develop`
- `@platforma-sdk/block-tools` was already at `2.6.68` (no change needed)