### PR TITLE
Fix cross-project deduplication for QC report, add tunable exportClones memory

### DIFF
--- a/.changeset/dedup-fixes.md
+++ b/.changeset/dedup-fixes.md
@@ -1,0 +1,12 @@
+---
+'@platforma-open/milaboratories.mixcr-clonotyping-2.workflow': minor
+'@platforma-open/milaboratories.mixcr-clonotyping-2': minor
+---
+
+Fix cross-project deduplication for QC report, add tunable memory for exportClones
+
+- Anonymize QC report inputs and deanonymize output TSV (structural render deduplicates across projects)
+- Pass `perProcessMemGB` as metaInput to QC report render (excluded from CID)
+- Add `perProcessMemGB` + `memGB()` pattern to export-report for exportClones memory (was hardcoded 16GiB)
+- Add `hash_override` to export-report template
+- Add `perProcessMemGB` to single-cell processColumn metaExtra

--- a/workflow/src/deanonymization.tpl.tengo
+++ b/workflow/src/deanonymization.tpl.tengo
@@ -1,0 +1,70 @@
+self := import("@platforma-sdk/workflow-tengo:tpl")
+smart := import("@platforma-sdk/workflow-tengo:smart")
+pt := import("@platforma-sdk/workflow-tengo:pt")
+maps := import("@platforma-sdk/workflow-tengo:maps")
+
+self.defineOutputs("deanonimizedTsv")
+
+self.awaitState("clusteringResult", "ResourceReady")
+self.awaitState("mapping", "ResourceReady")
+
+/**
+ * Builds a when/then/otherwise expression to replace values in a column based on a mapping.
+ * @param colExpr - pt column expression
+ * @param mapping - map from anonymized values (oldVal) to original values (newVal)
+ * @returns pt expression with value replacements
+ */
+buildReplaceExpression := func(colExpr, mapping) {
+	if len(mapping) == 0 {
+		return colExpr
+	}
+
+	whenExpr := undefined
+	maps.forEach(mapping, func(oldVal, newVal) {
+		condition := colExpr.eq(pt.lit(oldVal))
+		if is_undefined(whenExpr) {
+			whenExpr = pt.when(condition).then(pt.lit(newVal))
+		} else {
+			whenExpr = whenExpr.when(condition).then(pt.lit(newVal))
+		}
+	})
+
+	return whenExpr.otherwise(colExpr)
+}
+
+self.body(func(args) {
+	// Get mapping JSON
+	mappingJson := undefined
+	if smart.isResource(args.mapping) {
+		mappingJson = args.mapping.getDataAsJson()
+	} else if is_map(args.mapping) {
+		mappingJson = args.mapping
+	} else {
+		mappingResource := smart.resource(args.mapping)
+		mappingJson = mappingResource.getDataAsJson()
+	}
+
+	// Process TSV file
+	deanonimizedTsv := args.clusteringResult
+	if !is_undefined(deanonimizedTsv) {
+		wf := pt.workflow().mem("8GiB").cpu(2)
+
+		df := wf.frame(deanonimizedTsv, {
+			xsvType: "tsv",
+			inferSchema: false
+		})
+
+		// Replace anonymized sampleId values with real ones
+		df = df.withColumns(
+			buildReplaceExpression(pt.col("sampleId"), mappingJson).alias("sampleId")
+		)
+
+		df.save("result.tsv")
+		ptResult := wf.run()
+		deanonimizedTsv = ptResult.getFile("result.tsv")
+	}
+
+	return {
+		deanonimizedTsv: deanonimizedTsv
+	}
+})

--- a/workflow/src/export-report.tpl.tengo
+++ b/workflow/src/export-report.tpl.tengo
@@ -1,3 +1,5 @@
+//tengo:hash_override 9CA47368-4ECF-4CB7-91DF-9AAB5A33DCA8
+
 self := import("@platforma-sdk/workflow-tengo:tpl")
 smart := import("@platforma-sdk/workflow-tengo:smart")
 ll := import("@platforma-sdk/workflow-tengo:ll")
@@ -8,15 +10,14 @@ times := import("times")
 text := import("text")
 maps := import("@platforma-sdk/workflow-tengo:maps")
 pframes := import("@platforma-sdk/workflow-tengo:pframes")
-xsv := import("@platforma-sdk/workflow-tengo:pframes.xsv")
 slices := import("@platforma-sdk/workflow-tengo:slices")
 pConstants := import("@platforma-sdk/workflow-tengo:pframes.constants")
 pt := import("@platforma-sdk/workflow-tengo:pt")
-qcReportColumns := import(":qc-report-columns")
 
+math := import("math")
 json := import("json")
 
-self.defineOutputs("qcReportTable")
+self.defineOutputs("rawTsv")
 
 mixcrSw := assets.importSoftware("@platforma-open/milaboratories.software-mixcr:main")
 ptablerSw := assets.importSoftware("@platforma-open/milaboratories.software-ptabler:main")
@@ -43,6 +44,17 @@ self.body(func(inputs) {
         }
     }
     singleCellChainTsvsData := inputs.singleCellChainTsvsData
+	perProcessMemGB := inputs.perProcessMemGB
+
+	// Memory for downstream operations, linked to user override with hardcoded floors
+	baseMemGB := 64
+	if !is_undefined(perProcessMemGB) {
+		baseMemGB = perProcessMemGB
+	}
+	memGB := func(floorGB, divisor) {
+		return string(int(math.max(floorGB, baseMemGB / divisor))) + "GiB"
+	}
+
 	useStopCodonReplacement := !is_undefined(stopCodonTypes) && is_array(stopCodonTypes) && len(stopCodonTypes) > 0
 	if is_undefined(stopCodonReplacements) || !is_map(stopCodonReplacements) {
 		stopCodonReplacements = {}
@@ -208,7 +220,7 @@ self.body(func(inputs) {
         sampleId := json.decode(key)[0]
         exportFiltersCmd := exec.builder().
             inMediumQueue().
-            mem("16GiB").
+            mem(memGB(16, 2)).
             cpu(2).
             software(mixcrSw).
             env("MI_USE_SYSTEM_CA", "true").
@@ -279,7 +291,7 @@ self.body(func(inputs) {
                 sampleId := json.decode(key)[0]
                 exportChainFiltersCmd := exec.builder().
                     inMediumQueue().
-                    mem("16GiB").
+                    mem(memGB(16, 2)).
                     cpu(2).
                     software(mixcrSw).
                     env("MI_USE_SYSTEM_CA", "true").
@@ -500,18 +512,7 @@ self.body(func(inputs) {
     
     tsvFile := wfResult.getFile("qc-report-processed.tsv")
 
-    qcReportColumns := qcReportColumns(hasUmi, isSingleCell, sampleIdAxisSpec, chains, cellTags, umiTags, hasAssembleCells)
-    reportColumnsSpec := qcReportColumns.reportColumnsSpec
-
-    qcReportTable := xsv.importFile(
-		tsvFile,
-		"tsv",
-		reportColumnsSpec,
-		{ cpu: 1, mem: "16GiB" }
-	)
-
-    
     return {
-        qcReportTable: qcReportTable
+        rawTsv: tsvFile
     }
 })

--- a/workflow/src/process.tpl.tengo
+++ b/workflow/src/process.tpl.tengo
@@ -9,8 +9,10 @@ slices := import("@platforma-sdk/workflow-tengo:slices")
 maps := import("@platforma-sdk/workflow-tengo:maps")
 sets := import("@platforma-sdk/workflow-tengo:sets")
 anonymize := import("@platforma-sdk/workflow-tengo:anonymize")
+xsv := import("@platforma-sdk/workflow-tengo:pframes.xsv")
 
 calculateExportSpecs := import(":calculate-export-specs")
+qcReportColumnsLib := import(":qc-report-columns")
 
 json := import("json")
 text := import("text")
@@ -21,6 +23,7 @@ mixcrExportTpl := assets.importTemplate(":mixcr-export")
 aggregateByClonotypeKeyTpl := assets.importTemplate(":aggregate-by-clonotype-key")
 exportReportTpl := assets.importTemplate(":export-report")
 processSingleCellTpl := assets.importTemplate(":process-single-cell")
+deanonymizationTpl := assets.importTemplate(":deanonymization")
 
 self.awaitState("InputsLocked")
 self.awaitState("params", "ResourceReady")
@@ -842,6 +845,9 @@ self.body(func(inputs) {
 							schemaPerClonotypeNoAggregates: columnsToSchema(columnsSpecPerClonotypeNoAggregates),
 							shmMapping: shmMapping
 						}
+					},
+					metaExtra: {
+						perProcessMemGB: perProcessMemGB
 					}
 				}
 			)
@@ -879,19 +885,75 @@ self.body(func(inputs) {
 		}
 	}
 
-    qcReportTable := render.create(exportReportTpl, {
-		clnsData: mixcrResults.outputData("clns"),
+	// Anonymize sample-keyed ResourceMaps for QC report dedup across projects
+	anonInputs := {
+		clnsData: mixcrResults.outputData("clns")
+	}
+	for chain in chains {
+		if !is_undefined(clonotypeTablesData[chain]) {
+			anonInputs["clonotypeTablesData_" + chain] = clonotypeTablesData[chain]
+		}
+	}
+	if isSingleCell {
+		for chain in chains {
+			if !is_undefined(singleCellChainTsvs[chain]) {
+				anonInputs["singleCellChainTsvs_" + chain] = singleCellChainTsvs[chain]
+			}
+		}
+	}
+	anonResult := anonymize.anonymizePKeys(anonInputs, [0])
+
+	// Reconstruct anonymized maps
+	anonClonotypeTablesData := {}
+	for chain in chains {
+		key := "clonotypeTablesData_" + chain
+		if !is_undefined(anonResult.result[key]) {
+			anonClonotypeTablesData[chain] = anonResult.result[key]
+		}
+	}
+	anonSingleCellChainTsvs := {}
+	if isSingleCell {
+		for chain in chains {
+			key := "singleCellChainTsvs_" + chain
+			if !is_undefined(anonResult.result[key]) {
+				anonSingleCellChainTsvs[chain] = anonResult.result[key]
+			}
+		}
+	}
+
+	// Structural render with perProcessMemGB as meta input
+	qcReportRender := render.create(exportReportTpl, {
+		clnsData: anonResult.result["clnsData"],
 		presetSpecForBack: presetSpecForBack,
 		sampleIdAxisSpec: sampleIdAxisSpec,
-        chains: chains,
+		chains: chains,
 		library: library,
 		isLibraryFileGzipped: isLibraryFileGzipped,
-        clonotypeTablesData: clonotypeTablesData,
+		clonotypeTablesData: anonClonotypeTablesData,
 		productiveFeature: productiveFeature,
 		stopCodonTypes: params.stopCodonTypes,
 		stopCodonReplacements: params.stopCodonReplacements,
-		singleCellChainTsvsData: singleCellChainTsvs
+		singleCellChainTsvsData: anonSingleCellChainTsvs
+	}, {
+		metaInputs: {
+			perProcessMemGB: perProcessMemGB
+		}
 	})
+
+	// Deanonymize QC report raw TSV (restore real sampleIds via PTabler replacement)
+	deanonResult := render.createEphemeral(deanonymizationTpl, {
+		mapping: anonResult.mapping,
+		clusteringResult: qcReportRender.output("rawTsv")
+	})
+
+	// Import deanonymized TSV into PFrame
+	qcReportColumns := qcReportColumnsLib(hasUmi, isSingleCell, sampleIdAxisSpec, chains, presetSpecForBack.cellTags, presetSpecForBack.umiTags, hasAssembleCells)
+	qcReportTable := xsv.importFile(
+		deanonResult.output("deanonimizedTsv"),
+		"tsv",
+		qcReportColumns.reportColumnsSpec,
+		{ cpu: 1, mem: "16GiB" }
+	)
 
 	return {
 		"qc.spec": mixcrResults.outputSpec("qc"),
@@ -911,6 +973,6 @@ self.body(func(inputs) {
 		clonotypeTables: clonotypeTables.build(),
 
 		clonotypes: clonotypes.build(),
-		qcReportTable: qcReportTable.output("qcReportTable")
+		qcReportTable: qcReportTable
 	}
 })


### PR DESCRIPTION
## Summary
- Anonymize QC report inputs (`clnsData`, `clonotypeTablesData`, `singleCellChainTsvsData`) before structural `render.create`; deanonymize output TSV via ephemeral PTabler
- Pass `perProcessMemGB` as `metaInput` to QC report render (excluded from CID)
- Add `perProcessMemGB` + `memGB()` pattern to `export-report.tpl.tengo` for `mixcr exportClones` memory (was hardcoded 16GiB — will OOM on large datasets)
- Add `hash_override` to `export-report.tpl.tengo`
- Add `perProcessMemGB` to single-cell processColumn `metaExtra`

## Test plan
- [x] All 13 tests pass (including `simple project` and `simple sc project`)
- [x] Build succeeds