### PR TITLE
MILAB-6395: tolerate zero-byte MiXCR output in ptabler reads

### DIFF
--- a/.changeset/sc-empty-tsv-guard.md
+++ b/.changeset/sc-empty-tsv-guard.md
@@ -1,0 +1,7 @@
+---
+"@platforma-open/milaboratories.mixcr-clonotyping-2.workflow": patch
+---
+
+Tolerate zero-byte upstream MiXCR output across every ptabler read of MiXCR-produced TSVs. Previously these reads crashed with an opaque `polars.exceptions.NoDataError: empty CSV` whenever MiXCR emitted a 0-byte file (rare upstream failure mode, e.g. MiXCR JVM dying after the output file handle is opened but before any bytes are flushed). Now they use the new `raiseIfEmpty: false` option together with a complete declared schema, so the affected chain / sample yields an empty-but-valid result instead of a confusing cascade. Applied to the bulk and single-cell paths in `mixcr-export`, the per-sample reads in `aggregate-by-clonotype-key`, and `process-single-cell`.
+
+Requires `@platforma-sdk/workflow-tengo` and `@platforma-open/milaboratories.software-ptabler` with the matching `raiseIfEmpty` support.

--- a/workflow/src/aggregate-by-clonotype-key.tpl.tengo
+++ b/workflow/src/aggregate-by-clonotype-key.tpl.tengo
@@ -1,4 +1,4 @@
-//tengo:hash_override 8B1CFC68-2542-4C81-8CD4-F927B75F3975
+//tengo:hash_override FDFA108D-FE6B-4773-8DD5-425AA35A0E1B
 
 ll := import("@platforma-sdk/workflow-tengo:ll")
 self := import("@platforma-sdk/workflow-tengo:tpl")
@@ -63,7 +63,8 @@ self.body(func(inputs) {
 			schema: baseSchemaForRead
 		}, {
 			id: dfId,
-			inferSchema: false
+			inferSchema: false,
+			raiseIfEmpty: false
 		})
 		dataFrames = append(dataFrames, df)
 	}

--- a/workflow/src/mixcr-export.tpl.tengo
+++ b/workflow/src/mixcr-export.tpl.tengo
@@ -1,4 +1,4 @@
-//tengo:hash_override E5C1AD4C-B44D-4DE1-BBF1-4CB42ED7579A
+//tengo:hash_override 7753AB87-9E0A-4053-BF2F-8F5BDACEA85E
 
 ll := import("@platforma-sdk/workflow-tengo:ll")
 self := import("@platforma-sdk/workflow-tengo:tpl.light")
@@ -133,12 +133,39 @@ self.body(func(inputs) {
 		mem(ptMemGB * units.GiB).
 		cpu(2)
 
+	// Same defence as the single-cell path below: declare every column
+	// referenced downstream so a zero-byte MiXCR output yields an empty
+	// typed frame rather than a polars NoDataError.
+	mainReadSchema := [ { column: "readCount", type: "Double" } ]
+	mainReadSeen := { readCount: true }
+	mainAddCol := func(name, ty) {
+		if is_undefined(name) || name == "" { return }
+		if !is_undefined(mainReadSeen[name]) { return }
+		mainReadSeen[name] = true
+		mainReadSchema = append(mainReadSchema, { column: name, type: ty })
+	}
+	if !is_undefined(mainIsProductiveColumn) { mainAddCol(mainIsProductiveColumn, "String") }
+	for c in clonotypeKeyColumns { mainAddCol(c, "String") }
+	if chains == "TRA" || chains == "TRD" { mainAddCol("topChains", "String") }
+	if !is_undefined(aminoAcidSeqColumns) {
+		for c in aminoAcidSeqColumns { mainAddCol(c, "String") }
+	}
+	if !is_undefined(cdr3SeqColumns) {
+		for c in cdr3SeqColumns { mainAddCol(c, "String") }
+	}
+	if !is_undefined(aminoAcidSeqColumnPairs) {
+		for pair in aminoAcidSeqColumnPairs {
+			mainAddCol(pair.nt, "String")
+			mainAddCol(pair.aa, "String")
+		}
+	}
+
 	frameInputMap := {
 		file: unprocessedTsv,
 		xsvType: "tsv",
-		schema: [ { column: "readCount", type: "Double" } ]
+		schema: mainReadSchema
 	}
-	dfMain := wfMain.frame(frameInputMap, { inferSchema: false, id: "input_table" })
+	dfMain := wfMain.frame(frameInputMap, { inferSchema: false, raiseIfEmpty: false, id: "input_table" })
 
     dfMain.addColumns(
         pt.col("readCount").round().cast("Long").alias("readCount")
@@ -206,13 +233,45 @@ self.body(func(inputs) {
 			mem(ptMemGB * units.GiB).
 			cpu(2)
 
-		frameLoadOps := {
-			xsvType: "tsv",
-			inferSchema: false
+		// Schema covers every column referenced downstream so that, when MiXCR
+		// produces a zero-byte file (rare upstream failure mode), ptabler can
+		// synthesise an empty typed frame instead of raising NoDataError.
+		// raiseIfEmpty: false activates that synthesis path.
+		scReadSchema := []
+		scReadSeen := {}
+		scAddCol := func(name, ty) {
+			if is_undefined(name) || name == "" { return }
+			if !is_undefined(scReadSeen[name]) { return }
+			scReadSeen[name] = true
+			scReadSchema = append(scReadSchema, { column: name, type: ty })
+		}
+		if mainAbundanceColumnIsReadCount {
+			scAddCol("readCount", "Double")
+		}
+		if !is_undefined(mainIsProductiveColumn) { scAddCol(mainIsProductiveColumn, "String") }
+		for c in clonotypeKeyColumns { scAddCol(c, "String") }
+		if !is_undefined(cellTagColumns) {
+			for c in cellTagColumns { scAddCol(c, "String") }
+		}
+		if chains == "TRA" || chains == "TRD" { scAddCol("topChains", "String") }
+		if !is_undefined(aminoAcidSeqColumns) {
+			for c in aminoAcidSeqColumns { scAddCol(c, "String") }
+		}
+		if !is_undefined(cdr3SeqColumns) {
+			for c in cdr3SeqColumns { scAddCol(c, "String") }
+		}
+		if !is_undefined(aminoAcidSeqColumnPairs) {
+			for pair in aminoAcidSeqColumnPairs {
+				scAddCol(pair.nt, "String")
+				scAddCol(pair.aa, "String")
+			}
 		}
 
-		if mainAbundanceColumnIsReadCount {
-			frameLoadOps.schema = [ { column: "readCount", type: "Double" } ]
+		frameLoadOps := {
+			xsvType: "tsv",
+			inferSchema: false,
+			raiseIfEmpty: false,
+			schema: scReadSchema
 		}
 
 		dfSingleCell := wfSingleCell.frame(unprocessedTsvForSingleCell, frameLoadOps)

--- a/workflow/src/process-single-cell.tpl.tengo
+++ b/workflow/src/process-single-cell.tpl.tengo
@@ -1,4 +1,4 @@
-//tengo:hash_override AB9AC8BA-5FFC-40C5-B2F7-AC42181524F5
+//tengo:hash_override EFD29586-3707-4F2B-BC51-6D4844C6E5E2
 
 ll := import("@platforma-sdk/workflow-tengo:ll")
 self := import("@platforma-sdk/workflow-tengo:tpl.light")
@@ -76,7 +76,8 @@ self.body(func(inputs) {
 					{ column: mainAbundanceColumn, type: "Long" }, // Ensure mainAbundanceColumn is treated as Long
 					{ column: mainIsProductiveColumn, type: "String" } // Keep as String for direct comparison
 				],
-				inferSchema: false // Disable further inference so columns not defined in schema are interpreted as strings
+				inferSchema: false, // Disable further inference so columns not defined in schema are interpreted as strings
+				raiseIfEmpty: false // tolerate zero-byte upstream output; the declared schema is complete
 			}).withColumns(
 				pt.col("cellKey"), pt.col("clonotypeKey"), pt.col(mainAbundanceColumn), pt.col(mainIsProductiveColumn)
 			)


### PR DESCRIPTION
Notion: [MILAB-6395 — [pframes] don't fail on empty files from mixcr](https://app.notion.com/p/3753a83ff4af80329c91c0be63735a8a)

## Summary
- Every ptabler `frame()` that consumes MiXCR-produced TSV now opts into `raiseIfEmpty: false` plus a fully declared schema, so a rare 0-byte file from MiXCR yields an empty typed frame instead of an opaque polars `NoDataError: empty CSV`.
- Header-only TSVs (chain with zero clones) were already fine in polars — this fix targets the failure mode where upstream MiXCR wrote 0 bytes (e.g. JVM dying after the file handle is opened but before any bytes are flushed).
- Covered call sites: `mixcr-export` bulk (line ~141) and single-cell (line ~270), `aggregate-by-clonotype-key` per-sample read, `process-single-cell` per-sample read.
- `hash_override` bumped on the three modified templates so prior cached executions are not reused.

## Dependencies
Requires the matching `raiseIfEmpty` support in `@platforma-sdk/workflow-tengo` and `@platforma-open/milaboratories.software-ptabler` — see companion PR in `milaboratory/platforma`.

## Test plan
- [x] `pnpm build` at the block root — all 10 turbo tasks pass (build + lint + type-check).
- [ ] After the companion ptabler/SDK PR lands and gets published, bump catalog in this block and verify against a project that has both the live MiXCR-failure case (GSK customer telemetry) and a healthy run.
- [ ] Spot-check that downstream `mixcr-shm-trees` and `top-antibodies` still consume the (now possibly empty) per-chain outputs without errors.