### PR TITLE
MILAB-6480: migrate resource formula to fluent API (workflow-tengo 6.7.0)

### DIFF
--- a/.changeset/migrate-fluent-formula-api.md
+++ b/.changeset/migrate-fluent-formula-api.md
@@ -1,5 +1,6 @@
 ---
 "@platforma-open/milaboratories.mixcr-clonotyping-2.workflow": patch
+"@platforma-open/milaboratories.mixcr-clonotyping-2": patch
 ---
 
 Migrate the analyze exec's RAM sizing to the fluent `exec.formula` API (workflow-tengo 6.7.0): `.memFormula(f.clamp(...))` → `.resources({ onCPU: { cpu, ram } })`. Behavior-preserving — RAM stays `clamp(baseMemGiB + 4·size("reads"), baseMemGiB, 256 GiB)` with the same `baseMemGiB` fallback.

--- a/.changeset/migrate-fluent-formula-api.md
+++ b/.changeset/migrate-fluent-formula-api.md
@@ -1,0 +1,5 @@
+---
+"@platforma-open/milaboratories.mixcr-clonotyping-2.workflow": patch
+---
+
+Migrate the analyze exec's RAM sizing to the fluent `exec.formula` API (workflow-tengo 6.7.0): `.memFormula(f.clamp(...))` → `.resources({ onCPU: { cpu, ram } })`. Behavior-preserving — RAM stays `clamp(baseMemGiB + 4·size("reads"), baseMemGiB, 256 GiB)` with the same `baseMemGiB` fallback.

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -56,6 +56,15 @@ jobs:
 
           "AWS_CI_IAM_MONOREPO_SIMPLE_ROLE": ${{ toJSON(secrets.AWS_CI_IAM_MONOREPO_SIMPLE_ROLE) }},
           "AWS_CI_TURBOREPO_S3_BUCKET": ${{ toJSON(secrets.AWS_CI_TURBOREPO_S3_BUCKET) }},
+
+          "HZ_CI_TURBO_S3_BUCKET": ${{ toJSON(vars.HZ_CI_TURBO_S3_BUCKET) }},
+          "HZ_CI_TURBO_S3_ENDPOINT": ${{ toJSON(vars.HZ_CI_TURBO_S3_ENDPOINT) }},
+          "HZ_CI_TURBO_S3_REGION": ${{ toJSON(vars.HZ_CI_TURBO_S3_REGION) }},
+          "HZ_CI_TURBO_S3_ACCESS_KEY": ${{ toJSON(secrets.HZ_CI_TURBO_S3_ACCESS_KEY) }},
+          "HZ_CI_TURBO_S3_SECRET_KEY": ${{ toJSON(secrets.HZ_CI_TURBO_S3_SECRET_KEY) }},
+          "HZ_CI_CACHE_S3_ACCESS_KEY": ${{ toJSON(secrets.HZ_CI_CACHE_S3_ACCESS_KEY) }},
+          "HZ_CI_CACHE_S3_SECRET_KEY": ${{ toJSON(secrets.HZ_CI_CACHE_S3_SECRET_KEY) }},
+
           "PL_REGISTRY_PLATFORMA_OPEN_UPLOAD_URL": ${{ toJSON(secrets.PL_REGISTRY_PLOPEN_UPLOAD_URL) }},
           "QUAY_USERNAME": ${{ toJSON(secrets.QUAY_USERNAME) }},
           "QUAY_ROBOT_TOKEN": ${{ toJSON(secrets.QUAY_ROBOT_TOKEN) }} }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -40,8 +40,8 @@ catalogs:
       specifier: 1.79.20
       version: 1.79.20
     '@platforma-sdk/workflow-tengo':
-      specifier: 6.6.5
-      version: 6.6.5
+      specifier: 6.7.0
+      version: 6.7.0
     '@types/wicg-file-system-access':
       specifier: ^2023.10.7
       version: 2023.10.7
@@ -278,7 +278,7 @@ importers:
         version: 4.7.0-347-develop
       '@platforma-sdk/workflow-tengo':
         specifier: 'catalog:'
-        version: 6.6.5
+        version: 6.7.0
     devDependencies:
       '@platforma-sdk/tengo-builder':
         specifier: 'catalog:'
@@ -1583,8 +1583,14 @@ packages:
   '@platforma-open/milaboratories.software-ptabler@2.1.3':
     resolution: {integrity: sha512-4cikdkdJ5WYc0Nw3IoZxzlFNKvG1qCAqSjypq5b18pIK6LBDayzhFcuw5TDd8O3bAFhoHP+3cVTmoO9XUTYMRg==}
 
+  '@platforma-open/milaboratories.software-ptabler@2.1.4':
+    resolution: {integrity: sha512-hLGDR7xVKoKj+4IM+fiWmJjFvYCZ2JmDQ7/Z99nq1zglAJJ1dqqVrtZ2TJ67HNyORpe1CrkRXvP9kNc4JxBUgA==}
+
   '@platforma-open/milaboratories.software-ptexter@1.2.2':
     resolution: {integrity: sha512-I08YpKQ4+esLrfpVra5UJ+bznI9Zzba6OW0rKK407a1EUmanvYMVrCbM9gqnm6CHbv2vQxNGSaO8p1LoBh+9gA==}
+
+  '@platforma-open/milaboratories.software-ptexter@1.2.3':
+    resolution: {integrity: sha512-5wwzvPko/tjkm6EnirsnjB+MO5mF//tgJplI+jPh3bcSHpEdHF+B9xg+S1owAnekqbimMrFZWqHSVY9ZmIHOjw==}
 
   '@platforma-open/milaboratories.software-small-binaries.hello-world-py@1.0.10':
     resolution: {integrity: sha512-16BGRLIrsVW+YIaXwWLX6Nbm80PS5mQJEclHhjNbRrRTLHPaKI4RygZfBC0lLNzvHBiTXU4Qkh1+WmdovkshDg==}
@@ -1628,6 +1634,9 @@ packages:
 
   '@platforma-sdk/workflow-tengo@6.6.5':
     resolution: {integrity: sha512-BIY0DongPruQ7e2EMYy2b0UtO5ziGcLvr2RWgJ8ki17VKNzW3esm/RBszGHMrTYmXM0Yw7mCSasor4vH560g7A==}
+
+  '@platforma-sdk/workflow-tengo@6.7.0':
+    resolution: {integrity: sha512-hotcGbt42gbMRpNp4PEtE8TBLAQXn+V2LM1SCyY5cnc+tWXxUwhgQnfNsg/xOvbu2qxUZhVrGisvb7Ruj+L2IA==}
 
   '@protobuf-ts/grpc-transport@2.11.1':
     resolution: {integrity: sha512-l6wrcFffY+tuNnuyrNCkRM8hDIsAZVLA8Mn7PKdVyYxITosYh60qW663p9kL6TWXYuDCL3oxH8ih3vLKTDyhtg==}
@@ -6789,7 +6798,11 @@ snapshots:
 
   '@platforma-open/milaboratories.software-ptabler@2.1.3': {}
 
+  '@platforma-open/milaboratories.software-ptabler@2.1.4': {}
+
   '@platforma-open/milaboratories.software-ptexter@1.2.2': {}
+
+  '@platforma-open/milaboratories.software-ptexter@1.2.3': {}
 
   '@platforma-open/milaboratories.software-small-binaries.hello-world-py@1.0.10': {}
 
@@ -6930,6 +6943,14 @@ snapshots:
       '@milaboratories/software-pframes-conv': 2.2.9
       '@platforma-open/milaboratories.software-ptabler': 2.1.3
       '@platforma-open/milaboratories.software-ptexter': 1.2.2
+      '@platforma-open/milaboratories.software-small-binaries': 2.1.1
+
+  '@platforma-sdk/workflow-tengo@6.7.0':
+    dependencies:
+      '@milaboratories/pframes-rs-wasip2': 1.1.52
+      '@milaboratories/software-pframes-conv': 2.2.9
+      '@platforma-open/milaboratories.software-ptabler': 2.1.4
+      '@platforma-open/milaboratories.software-ptexter': 1.2.3
       '@platforma-open/milaboratories.software-small-binaries': 2.1.1
 
   '@protobuf-ts/grpc-transport@2.11.1(@grpc/grpc-js@1.13.4)':

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -25,8 +25,8 @@ catalogs:
       specifier: 4.7.0-347-develop
       version: 4.7.0-347-develop
     '@platforma-sdk/block-tools':
-      specifier: 2.11.5
-      version: 2.11.5
+      specifier: 2.12.0
+      version: 2.12.0
     '@platforma-sdk/model':
       specifier: 1.79.20
       version: 1.79.20
@@ -104,7 +104,7 @@ importers:
         version: 1.6.0(@types/node@24.10.2)(rollup@4.53.3)(vue@3.5.25(typescript@5.6.3))(yaml@2.8.2)
       '@platforma-sdk/block-tools':
         specifier: 'catalog:'
-        version: 2.11.5(@types/node@24.10.2)
+        version: 2.12.0(@types/node@24.10.2)
       js-yaml:
         specifier: 'catalog:'
         version: 4.1.1
@@ -137,7 +137,7 @@ importers:
         version: link:../workflow
       '@platforma-sdk/block-tools':
         specifier: 'catalog:'
-        version: 2.11.5(@types/node@24.10.2)
+        version: 2.12.0(@types/node@24.10.2)
       '@platforma-sdk/model':
         specifier: 'catalog:'
         version: 1.79.20
@@ -171,7 +171,7 @@ importers:
         version: 1.3.0
       '@platforma-sdk/block-tools':
         specifier: 'catalog:'
-        version: 2.11.5(@types/node@24.10.2)
+        version: 2.12.0(@types/node@24.10.2)
       '@types/node':
         specifier: '*'
         version: 24.10.2
@@ -376,6 +376,10 @@ packages:
   '@aws-crypto/util@5.2.0':
     resolution: {integrity: sha512-4RkU9EsI6ZpBve5fseQlGNUWKMa1RLPQ1dnjnQoe07ldfIzcsGb5hC5W0Dm7u423KWzawlrpbjXBrXCEv9zazQ==}
 
+  '@aws-sdk/client-ecr-public@3.859.0':
+    resolution: {integrity: sha512-pPY85lrGBNWynofNC6Er49W6aA4JvOOKC9RDbS8rWR8pBPEG6p0B82VQKFMR+3JYRogpfQf5hzU47um96EslFA==}
+    engines: {node: '>=18.0.0'}
+
   '@aws-sdk/client-s3@3.859.0':
     resolution: {integrity: sha512-oFLHZX1X6o54ZlweubtSVvQDz15JiNrgDD7KeMZT2MwxiI3axPcHzTo2uizjj5mgNapmYjRmQS5c1c63dvruVA==}
     engines: {node: '>=18.0.0'}
@@ -415,6 +419,12 @@ packages:
   '@aws-sdk/credential-provider-web-identity@3.858.0':
     resolution: {integrity: sha512-8iULWsH83iZDdUuiDsRb83M0NqIlXjlDbJUIddVsIrfWp4NmanKw77SV6yOZ66nuJjPsn9j7RDb9bfEPCy5SWA==}
     engines: {node: '>=18.0.0'}
+
+  '@aws-sdk/lib-storage@3.859.0':
+    resolution: {integrity: sha512-VfaEhih4MMxD6llibXEnrS4HyExhLpIFAvy1nq490IGO/Z6JCI81kmA3rB376XahMhoS9CVN0eAoeryTYHFHGw==}
+    engines: {node: '>=18.0.0'}
+    peerDependencies:
+      '@aws-sdk/client-s3': ^3.859.0
 
   '@aws-sdk/middleware-bucket-endpoint@3.840.0':
     resolution: {integrity: sha512-+gkQNtPwcSMmlwBHFd4saVVS11In6ID1HczNzpM3MXKXRBfSlbZJbCt6wN//AZ8HMklZEik4tcEOG0qa9UY8SQ==}
@@ -1124,6 +1134,10 @@ packages:
     resolution: {integrity: sha512-zOkD4aWNbembwI+AsPTz7nmWC1VPA4rwGBc+Nd5jPpKVh7rCtZwQrlOP5mVqRVMKIAjb1nU8kzzCGfqNPqfJjA==}
     engines: {node: '>=22'}
 
+  '@milaboratories/helpers@1.14.3':
+    resolution: {integrity: sha512-nZv+n+orVzA/GimDTNj6Yjb52+Wu5f/Kf2z6UCGXni6KTquLBfQhi3AFB1mLE7hkUYPvKU6LxuRY02CQMQiTVA==}
+    engines: {node: '>=22'}
+
   '@milaboratories/pf-driver@1.7.14':
     resolution: {integrity: sha512-JRuMmuhObyD27MtpCcimGklr2yMJ2PobcYJ2y5k+UuhQWXKllhEDlUAyv2Xw/I7Xxym8Nn2npcVdOaJvTP3bPA==}
     engines: {node: '>=22.19.0'}
@@ -1150,6 +1164,10 @@ packages:
 
   '@milaboratories/pl-client@3.12.0':
     resolution: {integrity: sha512-uca6tbW7hy7H/Sf010/9HNQMFKwf6bJ/JONyNgvQB+hGdJZb//vjw0xoBQDun0wSAkPm+9H2I+e0q6RUfcNZng==}
+    engines: {node: '>=22.19.0'}
+
+  '@milaboratories/pl-client@3.13.2':
+    resolution: {integrity: sha512-5sx6ehEPfo7q4ojyXgPgQIzn4iPZs7YPvEPctRkwQ6cuK5KzLO059FjzUjsJDh5Si7QbUL/yi5qxCf1h1q4G6g==}
     engines: {node: '>=22.19.0'}
 
   '@milaboratories/pl-config@1.8.2':
@@ -1180,11 +1198,20 @@ packages:
     resolution: {integrity: sha512-d71/T3zlTtunFgVum28FLhlZuKuwpT591B2ZfZVO6Jamd8nY54CxcBmIsIG4xVTqitvsQhNFiAJdkoYgXE6Inw==}
     engines: {node: '>=22.19.0'}
 
+  '@milaboratories/pl-model-backend@1.4.13':
+    resolution: {integrity: sha512-HGEVDZXh/XUU5sDuBB46pMc1+46elzvrPuKCaowhqpzBPzA4j/DNxuJucJRv/h/oE0Ue3kEQf+6x0506kGDrow==}
+
   '@milaboratories/pl-model-backend@1.4.9':
     resolution: {integrity: sha512-84+Pv2RhonE/ZwR5bXipOGK4cC5V3C4vmhzIgc8TWpgLxUNsjCjoodSo3bzPcpA+URShTf4+3h4C28O/wO/MCw==}
 
   '@milaboratories/pl-model-common@1.46.2':
     resolution: {integrity: sha512-VEeauisApYScvCS8lnK3zpFJ520xuTAodKJmjR8ulHcMrWMyWMfHEdGb7j5OMD0mM/OwTgmQrrJ5eB7Xd+xoOQ==}
+
+  '@milaboratories/pl-model-common@1.46.4':
+    resolution: {integrity: sha512-QArgLyQkf8kHSQquxStyk5Xfnau8S4M2vKEbUVQRRoZCzLU1lcDVXRwGgAzRH5NizeqYNrB/wt0/tShajH+6eA==}
+
+  '@milaboratories/pl-model-middle-layer@1.30.11':
+    resolution: {integrity: sha512-yFThwVqOTb2gJw/tp4PkZcsKI7yRRJCX3QuA6fIc2+tNxCqyEQmdpLmaIY/nhaziIp9ByBT9MrzWNIQd1T9aww==}
 
   '@milaboratories/pl-model-middle-layer@1.30.7':
     resolution: {integrity: sha512-rs9x3Ron4ujR/UOdEgB8WUB1SvZ8ZAScT1Av/e4or+iiQ/CzhmK9nqtYamHVwKV+JgwIFbXQwxGvIHDVz955dQ==}
@@ -1219,6 +1246,10 @@ packages:
 
   '@milaboratories/ts-helpers@1.8.3':
     resolution: {integrity: sha512-HK3AmNZl2fOzMHot2+ihKsOC+fluwhl5261VTn1zGS3LRpmC9bCk/po8SzsVmg79ccI5nESFTdz+BRaLsXncmQ==}
+    engines: {node: '>=22.19.0'}
+
+  '@milaboratories/ts-helpers@1.8.4':
+    resolution: {integrity: sha512-YdOyANkJjFiEZgS3bfbludDo9PWOQZQ8AhGw/rpO5/7bgQ9RIVOOTAtP5/UppANoeUiYhCgJt/xvIZgnQ/PZ0w==}
     engines: {node: '>=22.19.0'}
 
   '@milaboratories/uikit@2.15.11':
@@ -1614,12 +1645,19 @@ packages:
     resolution: {integrity: sha512-dM4KLiJLz3zQgJfJklq9M8/Q5yTIiaDLZ2ui1o0fsKoe3wB+cGA0VJCNAjjgLeKmvZd6zqd+2OmXpCn5pOBn+g==}
     hasBin: true
 
+  '@platforma-sdk/block-tools@2.12.0':
+    resolution: {integrity: sha512-G6HcBp2tmwSoFuouxYHmHWFDkjc2DYd+zZreFoQTt4+IAlzQ2pyE8RBbB9edtN7/nKKCLuljBkg3Gcn1htzZbw==}
+    hasBin: true
+
   '@platforma-sdk/blocks-deps-updater@2.2.0':
     resolution: {integrity: sha512-p9lBxhFXM9WoRsrJO7dfkiXSK+1m63yIn1sKhBO71eMbhrLMyVYHEOeNf3w5OCdbRF5QsNhXzWuiTmFK3zHFsA==}
     hasBin: true
 
   '@platforma-sdk/model@1.79.20':
     resolution: {integrity: sha512-0ULETzwgo4E5rIddn/PoCAY5gSv9luDYAaSp66b8u3u1XTh43k7fgOpobu/rrfHJMiY9IGfzALDlo6jtvMLUyQ==}
+
+  '@platforma-sdk/package-builder-lib@1.2.0':
+    resolution: {integrity: sha512-AtSzaZ39BGlqcyYtpGREDz+YlGCDdSTQJNV/+NkTyUtoq1ECRO+iMqAX1DSSza1WqylnURX8vKVI2owS/cxntA==}
 
   '@platforma-sdk/tengo-builder@4.0.11':
     resolution: {integrity: sha512-c0LuiR7vtclto853Q1O+j8g109ooIZKtEl5tqRHG6dN/kk6S+J7DZHCpAjFuZ9pt3x6jF95sNaJEtP8uFs1uXw==}
@@ -2559,6 +2597,10 @@ packages:
     resolution: {integrity: sha512-AO2ac6pjRB3SJmGJo+v5/aK6Omggp6fsLrs6wN9bd35ulu4cCwaAU9+7ZhXjeqHVkaHThLuzH0nZr0YpCDhygg==}
     engines: {node: ^18.17.0 || >=20.5.0}
 
+  abort-controller@3.0.0:
+    resolution: {integrity: sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==}
+    engines: {node: '>=6.5'}
+
   acorn-jsx@5.3.2:
     resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}
     peerDependencies:
@@ -2649,6 +2691,14 @@ packages:
   ansi-styles@6.2.3:
     resolution: {integrity: sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==}
     engines: {node: '>=12'}
+
+  archiver-utils@5.0.2:
+    resolution: {integrity: sha512-wuLJMmIBQYCsGZgYLTy5FIB2pF6Lfb6cXMSF8Qywwk3t20zWnAi7zLcQFdKQmIB8wyZpY5ER38x08GbwtR2cLA==}
+    engines: {node: '>= 14'}
+
+  archiver@7.0.1:
+    resolution: {integrity: sha512-ZcbTaIqJOfCc03QwD468Unz/5Ir8ATtvAHsK+FdXbDIbGfihqh9mrvdcYunQzqn4HrvWWaFyaxJhGZagaJJpPQ==}
+    engines: {node: '>= 14'}
 
   argparse@1.0.10:
     resolution: {integrity: sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==}
@@ -2788,11 +2838,21 @@ packages:
   buffer-crc32@0.2.13:
     resolution: {integrity: sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==}
 
+  buffer-crc32@1.0.0:
+    resolution: {integrity: sha512-Db1SbgBS/fg/392AblrMJk97KggmvYhr4pB5ZIMTWtaivCPMWLkmb7m21cJvpvgK+J3nsU2CmmixNBZx4vFj/w==}
+    engines: {node: '>=8.0.0'}
+
   buffer-fill@1.0.0:
     resolution: {integrity: sha512-T7zexNBwiiaCOGDg9xNX9PBmjrubblRkENuptryuI64URkXDFum9il/JGL8Lm8wYfAXpredVXXZz7eMHilimiQ==}
 
+  buffer@5.6.0:
+    resolution: {integrity: sha512-/gDYp/UtU0eA1ys8bOs9J6a+E/KWIY+DZ+Q2WESNUA0jFRsJOc0SNUO6xJ5SGA1xueg3NL65W6s+NY5l9cunuw==}
+
   buffer@5.7.1:
     resolution: {integrity: sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==}
+
+  buffer@6.0.3:
+    resolution: {integrity: sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==}
 
   buildcheck@0.0.7:
     resolution: {integrity: sha512-lHblz4ahamxpTmnsk+MNTRWsjYKv965MwOrSJyeD588rR3Jcu7swE+0wN5F+PbL5cjgu/9ObkhfzEPuofEMwLA==}
@@ -2899,6 +2959,10 @@ packages:
   compare-versions@6.1.1:
     resolution: {integrity: sha512-4hm4VPpIecmlg59CHXnRDnqGplJFrbLG4aFEl5vl6cK1u76ws3LLvX7ikFnTDl5vo39sjWD6AaDPYodJp/NNHg==}
 
+  compress-commons@6.0.2:
+    resolution: {integrity: sha512-6FqVXeETqWPoGcfzrXb37E50NP0LXT8kAMu5ooZayhWWdgEY4lBEEcbQNXtkuKQsGduxiIcI4gOTsxTmuq/bSg==}
+    engines: {node: '>= 14'}
+
   concat-map@0.0.1:
     resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
 
@@ -2924,6 +2988,15 @@ packages:
   cpu-features@0.0.10:
     resolution: {integrity: sha512-9IkYqtX3YHPCzoVg1Py+o9057a3i0fp7S530UWokCSaFVTc7CwXPRiOjRjBQQ18ZCNafx78YfnG+HALxtVmOGA==}
     engines: {node: '>=10.0.0'}
+
+  crc-32@1.2.2:
+    resolution: {integrity: sha512-ROmzCKrTnOwybPcJApAA6WBWij23HVfGVNKqqrZpuyZOHqK2CwHSvpGuyt/UNNvaIjEd8X5IFGp4Mh+Ie1IHJQ==}
+    engines: {node: '>=0.8'}
+    hasBin: true
+
+  crc32-stream@6.0.0:
+    resolution: {integrity: sha512-piICUB6ei4IlTv1+653yq5+KoqfBYmj9bw6LqXoOneTMDXk5nM1qt12mFW1caG3LlJXEKW1Bp0WggEmIfQB34g==}
+    engines: {node: '>= 14'}
 
   cross-spawn@6.0.6:
     resolution: {integrity: sha512-VqCUuhcd1iB+dsv8gxPttb5iZh/D0iubSP21g36KXdEuf6I5JiioesUVjpCdHV9MZRUfVFlvwtIUyPfxo5trtw==}
@@ -3170,8 +3243,16 @@ packages:
     resolution: {integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==}
     engines: {node: '>=0.10.0'}
 
+  event-target-shim@5.0.1:
+    resolution: {integrity: sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==}
+    engines: {node: '>=6'}
+
   events-universal@1.0.1:
     resolution: {integrity: sha512-LUd5euvbMLpwOF8m6ivPCbhQeSiYVNb8Vs0fQ8QjXo0JTkEHpz8pxdQf0gStltaPpw0Cca8b39KxvK9cfKRiAw==}
+
+  events@3.3.0:
+    resolution: {integrity: sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==}
+    engines: {node: '>=0.8.x'}
 
   execa@1.0.0:
     resolution: {integrity: sha512-adbxcyWV46qiHyvSp50TKt05tB4tK3HcmF7/nxfAdhnox83seTDbwnaqKO4sXRy7roHAIFqJP/Rw/AuEbX61LA==}
@@ -3593,6 +3674,10 @@ packages:
   kuler@2.0.0:
     resolution: {integrity: sha512-Xq9nH7KlWZmXAtodXDDRE7vs6DU1gTU8zYDHDiWLSip45Egwq3plLHzPn27NgvzL2r1LMPC1vdqh98sQxtqj4A==}
 
+  lazystream@1.0.1:
+    resolution: {integrity: sha512-b94GiNHQNy6JNTrt5w6zNyffMrNkXZb3KTkCZJb2V1xaEGCk093vkZ2jk3tpaeP33/OiXC+WvK9AxUebnf5nbw==}
+    engines: {node: '>= 0.6.3'}
+
   levn@0.4.1:
     resolution: {integrity: sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==}
     engines: {node: '>= 0.8.0'}
@@ -3761,6 +3846,10 @@ packages:
   minimatch@3.1.2:
     resolution: {integrity: sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==}
 
+  minimatch@5.1.9:
+    resolution: {integrity: sha512-7o1wEA2RyMP7Iu7GNba9vc0RWWGACJOCZBJX2GJWip0ikV+wcOsgVuY9uE8CPiyQhkGFSlhuSkZPavN7u1c2Fw==}
+    engines: {node: '>=10'}
+
   minimatch@9.0.1:
     resolution: {integrity: sha512-0jWhJpD/MdhPXwPuiRkCbfYfSKp2qnn2eOc279qI7f+osl/l+prKSrvhg157zSYvx/1nmgn2NqdT6k2Z7zSH9w==}
     engines: {node: '>=16 || 14 >=14.17'}
@@ -3842,6 +3931,10 @@ packages:
     resolution: {integrity: sha512-ieGu42u/Qsa4TFktmaKEwM6MQH0pOWnaB3htzh0JRtx84+Mebc0cbZYN5bC+6WTZ4+77xrL9Pn5m7CV6VIkV7A==}
     engines: {node: ^18.17.0 || >=20.5.0}
     hasBin: true
+
+  normalize-path@3.0.0:
+    resolution: {integrity: sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==}
+    engines: {node: '>=0.10.0'}
 
   npm-run-path@2.0.2:
     resolution: {integrity: sha512-lJxZYlT4DW/bRUtFh1MQIWqmLwQfAxnqWG4HhEdjMlkrJYnJn0Jrr2u3mgxqaWsdiBc76TYkTG/mhrnYTuzfHw==}
@@ -4055,6 +4148,10 @@ packages:
   process-nextick-args@2.0.1:
     resolution: {integrity: sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==}
 
+  process@0.11.10:
+    resolution: {integrity: sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==}
+    engines: {node: '>= 0.6.0'}
+
   proto-list@1.2.4:
     resolution: {integrity: sha512-vtK/94akxsTMhe0/cbfpR+syPuszcuwhqVjJq26CuNDgFGj682oRBXOP5MJpv2r7JtE8MsiepGIqvvOTBwn2vA==}
 
@@ -4103,6 +4200,13 @@ packages:
   readable-stream@3.6.2:
     resolution: {integrity: sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==}
     engines: {node: '>= 6'}
+
+  readable-stream@4.7.0:
+    resolution: {integrity: sha512-oIGGmcpTLwPga8Bn6/Z75SVaH1z5dUut2ibSyAMVhmUggWpmDn2dapB0n7f8nwaSiRtepAsfJyfXIO5DCVAODg==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+
+  readdir-glob@1.1.3:
+    resolution: {integrity: sha512-v05I2k7xN8zXvPD9N+z/uhXPaj0sUFCe2rcWZIpBsqxfP7xXFQ0tipAd/wjj1YxWyWtUS5IDJpOG82JKt2EAVA==}
 
   rechoir@0.6.2:
     resolution: {integrity: sha512-HFM8rkZ+i3zrV+4LQjwQ0W+ez98pApMGM3HUrN04j3CqzPOzl9nmP15Y8YXNm8QHGv/eacOVEjqhmWpkRV0NAw==}
@@ -4314,6 +4418,9 @@ packages:
 
   std-env@4.0.0:
     resolution: {integrity: sha512-zUMPtQ/HBY3/50VbpkupYHbRroTRZJPRLvreamgErJVys0ceuzMkD44J/QjqhHjOzK42GQ3QZIeFG1OYfOtKqQ==}
+
+  stream-browserify@3.0.0:
+    resolution: {integrity: sha512-H73RAHsVBapbim0tU2JwwOiXUj+fikfiaoYAKHF3VJfA0pe2BCzkhAHBlLG6REzE+2WNZcxOXjK7lkso+9euLA==}
 
   streamx@2.23.0:
     resolution: {integrity: sha512-kn+e44esVfn2Fa/O0CPFcex27fjIL6MkVae0Mm6q+E6f0hWv578YCERbv+4m02cjxvDsPKLnmxral/rR6lBMAg==}
@@ -4887,6 +4994,10 @@ packages:
     resolution: {integrity: sha512-U/PBtDf35ff0D8X8D0jfdzHYEPFxAI7jJlxZXwCSez5M3190m+QobIfh+sWDWSHMCWWJN2AWamkegn6vr6YBTw==}
     engines: {node: '>=18'}
 
+  zip-stream@6.0.1:
+    resolution: {integrity: sha512-zK7YHHz4ZXpW89AHXUPbQVGKI7uvkd3hzusTdotCg1UxyaVtg0zFJSTfW/Dq5f7OBBVnq6cZIaC8Ti4hb6dtCA==}
+    engines: {node: '>= 14'}
+
   zod@3.25.76:
     resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
 
@@ -4977,6 +5088,50 @@ snapshots:
       '@aws-sdk/types': 3.840.0
       '@smithy/util-utf8': 2.3.0
       tslib: 2.8.1
+
+  '@aws-sdk/client-ecr-public@3.859.0':
+    dependencies:
+      '@aws-crypto/sha256-browser': 5.2.0
+      '@aws-crypto/sha256-js': 5.2.0
+      '@aws-sdk/core': 3.858.0
+      '@aws-sdk/credential-provider-node': 3.859.0
+      '@aws-sdk/middleware-host-header': 3.840.0
+      '@aws-sdk/middleware-logger': 3.840.0
+      '@aws-sdk/middleware-recursion-detection': 3.840.0
+      '@aws-sdk/middleware-user-agent': 3.858.0
+      '@aws-sdk/region-config-resolver': 3.840.0
+      '@aws-sdk/types': 3.840.0
+      '@aws-sdk/util-endpoints': 3.848.0
+      '@aws-sdk/util-user-agent-browser': 3.840.0
+      '@aws-sdk/util-user-agent-node': 3.858.0
+      '@smithy/config-resolver': 4.4.3
+      '@smithy/core': 3.18.7
+      '@smithy/fetch-http-handler': 5.3.6
+      '@smithy/hash-node': 4.2.5
+      '@smithy/invalid-dependency': 4.2.5
+      '@smithy/middleware-content-length': 4.2.5
+      '@smithy/middleware-endpoint': 4.3.14
+      '@smithy/middleware-retry': 4.4.14
+      '@smithy/middleware-serde': 4.2.6
+      '@smithy/middleware-stack': 4.2.5
+      '@smithy/node-config-provider': 4.3.5
+      '@smithy/node-http-handler': 4.4.5
+      '@smithy/protocol-http': 5.3.5
+      '@smithy/smithy-client': 4.9.10
+      '@smithy/types': 4.9.0
+      '@smithy/url-parser': 4.2.5
+      '@smithy/util-base64': 4.3.0
+      '@smithy/util-body-length-browser': 4.2.0
+      '@smithy/util-body-length-node': 4.2.1
+      '@smithy/util-defaults-mode-browser': 4.3.13
+      '@smithy/util-defaults-mode-node': 4.2.16
+      '@smithy/util-endpoints': 3.2.5
+      '@smithy/util-middleware': 4.2.5
+      '@smithy/util-retry': 4.2.5
+      '@smithy/util-utf8': 4.2.0
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - aws-crt
 
   '@aws-sdk/client-s3@3.859.0':
     dependencies:
@@ -5190,6 +5345,17 @@ snapshots:
       tslib: 2.8.1
     transitivePeerDependencies:
       - aws-crt
+
+  '@aws-sdk/lib-storage@3.859.0(@aws-sdk/client-s3@3.859.0)':
+    dependencies:
+      '@aws-sdk/client-s3': 3.859.0
+      '@smithy/abort-controller': 4.2.5
+      '@smithy/middleware-endpoint': 4.3.14
+      '@smithy/smithy-client': 4.9.10
+      buffer: 5.6.0
+      events: 3.3.0
+      stream-browserify: 3.0.0
+      tslib: 2.8.1
 
   '@aws-sdk/middleware-bucket-endpoint@3.840.0':
     dependencies:
@@ -6123,6 +6289,8 @@ snapshots:
 
   '@milaboratories/helpers@1.14.2': {}
 
+  '@milaboratories/helpers@1.14.3': {}
+
   '@milaboratories/pf-driver@1.7.14(@bytecodealliance/preview2-shim@0.17.9)':
     dependencies:
       '@milaboratories/helpers': 1.14.2
@@ -6183,6 +6351,24 @@ snapshots:
       '@milaboratories/pl-http': 1.2.4
       '@milaboratories/pl-model-common': 1.46.2
       '@milaboratories/ts-helpers': 1.8.3
+      '@protobuf-ts/grpc-transport': 2.11.1(@grpc/grpc-js@1.13.4)
+      '@protobuf-ts/runtime': 2.11.1
+      '@protobuf-ts/runtime-rpc': 2.11.1
+      canonicalize: 2.1.0
+      denque: 2.1.0
+      long: 5.3.2
+      lru-cache: 11.2.4
+      openapi-fetch: 0.15.0
+      undici: 7.16.0
+      utility-types: 3.11.0
+      yaml: 2.8.2
+
+  '@milaboratories/pl-client@3.13.2':
+    dependencies:
+      '@grpc/grpc-js': 1.13.4
+      '@milaboratories/pl-http': 1.2.4
+      '@milaboratories/pl-model-common': 1.46.4
+      '@milaboratories/ts-helpers': 1.8.4
       '@protobuf-ts/grpc-transport': 2.11.1(@grpc/grpc-js@1.13.4)
       '@protobuf-ts/runtime': 2.11.1
       '@protobuf-ts/runtime-rpc': 2.11.1
@@ -6307,6 +6493,12 @@ snapshots:
       - react-native-b4a
       - supports-color
 
+  '@milaboratories/pl-model-backend@1.4.13':
+    dependencies:
+      '@milaboratories/pl-client': 3.13.2
+      canonicalize: 2.1.0
+      zod: 3.25.76
+
   '@milaboratories/pl-model-backend@1.4.9':
     dependencies:
       '@milaboratories/pl-client': 3.12.0
@@ -6318,6 +6510,21 @@ snapshots:
       '@milaboratories/helpers': 1.14.2
       '@milaboratories/pl-error-like': 1.12.10
       canonicalize: 2.1.0
+      zod: 3.25.76
+
+  '@milaboratories/pl-model-common@1.46.4':
+    dependencies:
+      '@milaboratories/helpers': 1.14.3
+      '@milaboratories/pl-error-like': 1.12.10
+      canonicalize: 2.1.0
+      zod: 3.25.76
+
+  '@milaboratories/pl-model-middle-layer@1.30.11':
+    dependencies:
+      '@milaboratories/helpers': 1.14.3
+      '@milaboratories/pl-model-common': 1.46.4
+      es-toolkit: 1.42.0
+      utility-types: 3.11.0
       zod: 3.25.76
 
   '@milaboratories/pl-model-middle-layer@1.30.7':
@@ -6484,6 +6691,12 @@ snapshots:
   '@milaboratories/ts-helpers@1.8.3':
     dependencies:
       '@milaboratories/helpers': 1.14.2
+      canonicalize: 2.1.0
+      denque: 2.1.0
+
+  '@milaboratories/ts-helpers@1.8.4':
+    dependencies:
+      '@milaboratories/helpers': 1.14.3
       canonicalize: 2.1.0
       denque: 2.1.0
 
@@ -6845,6 +7058,33 @@ snapshots:
       - '@types/node'
       - aws-crt
 
+  '@platforma-sdk/block-tools@2.12.0(@types/node@24.10.2)':
+    dependencies:
+      '@aws-sdk/client-ecr-public': 3.859.0
+      '@aws-sdk/client-s3': 3.859.0
+      '@inquirer/prompts': 7.10.1(@types/node@24.10.2)
+      '@milaboratories/pl-http': 1.2.4
+      '@milaboratories/pl-model-backend': 1.4.13
+      '@milaboratories/pl-model-common': 1.46.4
+      '@milaboratories/pl-model-middle-layer': 1.30.11
+      '@milaboratories/resolve-helper': 1.1.3
+      '@milaboratories/ts-helpers': 1.8.4
+      '@platforma-sdk/blocks-deps-updater': 2.2.0
+      '@platforma-sdk/package-builder-lib': 1.2.0
+      canonicalize: 2.1.0
+      commander: 15.0.0
+      lru-cache: 11.2.4
+      mime-types: 2.1.35
+      tar: 7.5.2
+      undici: 7.16.0
+      yaml: 2.8.2
+      zod: 3.25.76
+    transitivePeerDependencies:
+      - '@types/node'
+      - aws-crt
+      - bare-abort-controller
+      - react-native-b4a
+
   '@platforma-sdk/blocks-deps-updater@2.2.0':
     dependencies:
       yaml: 2.8.2
@@ -6861,6 +7101,21 @@ snapshots:
       fast-json-patch: 3.1.1
       utility-types: 3.11.0
       zod: 3.25.76
+
+  '@platforma-sdk/package-builder-lib@1.2.0':
+    dependencies:
+      '@aws-sdk/client-s3': 3.859.0
+      '@aws-sdk/lib-storage': 3.859.0(@aws-sdk/client-s3@3.859.0)
+      '@milaboratories/resolve-helper': 1.1.3
+      archiver: 7.0.1
+      undici: 7.16.0
+      winston: 3.19.0
+      yaml: 2.8.2
+      zod: 3.25.76
+    transitivePeerDependencies:
+      - aws-crt
+      - bare-abort-controller
+      - react-native-b4a
 
   '@platforma-sdk/tengo-builder@4.0.11':
     dependencies:
@@ -7954,6 +8209,10 @@ snapshots:
 
   abbrev@3.0.1: {}
 
+  abort-controller@3.0.0:
+    dependencies:
+      event-target-shim: 5.0.1
+
   acorn-jsx@5.3.2(acorn@8.15.0):
     dependencies:
       acorn: 8.15.0
@@ -8045,6 +8304,29 @@ snapshots:
       color-convert: 2.0.1
 
   ansi-styles@6.2.3: {}
+
+  archiver-utils@5.0.2:
+    dependencies:
+      glob: 10.5.0
+      graceful-fs: 4.2.11
+      is-stream: 2.0.1
+      lazystream: 1.0.1
+      lodash: 4.17.21
+      normalize-path: 3.0.0
+      readable-stream: 4.7.0
+
+  archiver@7.0.1:
+    dependencies:
+      archiver-utils: 5.0.2
+      async: 3.2.6
+      buffer-crc32: 1.0.0
+      readable-stream: 4.7.0
+      readdir-glob: 1.1.3
+      tar-stream: 3.1.7
+      zip-stream: 6.0.1
+    transitivePeerDependencies:
+      - bare-abort-controller
+      - react-native-b4a
 
   argparse@1.0.10:
     dependencies:
@@ -8185,9 +8467,21 @@ snapshots:
 
   buffer-crc32@0.2.13: {}
 
+  buffer-crc32@1.0.0: {}
+
   buffer-fill@1.0.0: {}
 
+  buffer@5.6.0:
+    dependencies:
+      base64-js: 1.5.1
+      ieee754: 1.2.1
+
   buffer@5.7.1:
+    dependencies:
+      base64-js: 1.5.1
+      ieee754: 1.2.1
+
+  buffer@6.0.3:
     dependencies:
       base64-js: 1.5.1
       ieee754: 1.2.1
@@ -8276,6 +8570,14 @@ snapshots:
 
   compare-versions@6.1.1: {}
 
+  compress-commons@6.0.2:
+    dependencies:
+      crc-32: 1.2.2
+      crc32-stream: 6.0.0
+      is-stream: 2.0.1
+      normalize-path: 3.0.0
+      readable-stream: 4.7.0
+
   concat-map@0.0.1: {}
 
   confbox@0.1.8: {}
@@ -8298,6 +8600,13 @@ snapshots:
       buildcheck: 0.0.7
       nan: 2.24.0
     optional: true
+
+  crc-32@1.2.2: {}
+
+  crc32-stream@6.0.0:
+    dependencies:
+      crc-32: 1.2.2
+      readable-stream: 4.7.0
 
   cross-spawn@6.0.6:
     dependencies:
@@ -8574,11 +8883,15 @@ snapshots:
 
   esutils@2.0.3: {}
 
+  event-target-shim@5.0.1: {}
+
   events-universal@1.0.1:
     dependencies:
       bare-events: 2.8.2
     transitivePeerDependencies:
       - bare-abort-controller
+
+  events@3.3.0: {}
 
   execa@1.0.0:
     dependencies:
@@ -8975,6 +9288,10 @@ snapshots:
 
   kuler@2.0.0: {}
 
+  lazystream@1.0.1:
+    dependencies:
+      readable-stream: 2.3.8
+
   levn@0.4.1:
     dependencies:
       prelude-ls: 1.2.1
@@ -9121,6 +9438,10 @@ snapshots:
     dependencies:
       brace-expansion: 1.1.12
 
+  minimatch@5.1.9:
+    dependencies:
+      brace-expansion: 2.0.2
+
   minimatch@9.0.1:
     dependencies:
       brace-expansion: 2.0.2
@@ -9182,6 +9503,8 @@ snapshots:
   nopt@8.1.0:
     dependencies:
       abbrev: 3.0.1
+
+  normalize-path@3.0.0: {}
 
   npm-run-path@2.0.2:
     dependencies:
@@ -9406,6 +9729,8 @@ snapshots:
 
   process-nextick-args@2.0.1: {}
 
+  process@0.11.10: {}
+
   proto-list@1.2.4: {}
 
   protobufjs@7.5.4:
@@ -9481,6 +9806,18 @@ snapshots:
       inherits: 2.0.4
       string_decoder: 1.3.0
       util-deprecate: 1.0.2
+
+  readable-stream@4.7.0:
+    dependencies:
+      abort-controller: 3.0.0
+      buffer: 6.0.3
+      events: 3.3.0
+      process: 0.11.10
+      string_decoder: 1.3.0
+
+  readdir-glob@1.1.3:
+    dependencies:
+      minimatch: 5.1.9
 
   rechoir@0.6.2:
     dependencies:
@@ -9718,6 +10055,11 @@ snapshots:
   std-env@3.10.0: {}
 
   std-env@4.0.0: {}
+
+  stream-browserify@3.0.0:
+    dependencies:
+      inherits: 2.0.4
+      readable-stream: 3.6.2
 
   streamx@2.23.0:
     dependencies:
@@ -10251,5 +10593,11 @@ snapshots:
   yocto-queue@0.1.0: {}
 
   yoctocolors-cjs@2.1.3: {}
+
+  zip-stream@6.0.1:
+    dependencies:
+      archiver-utils: 5.0.2
+      compress-commons: 6.0.2
+      readable-stream: 4.7.0
 
   zod@3.25.76: {}

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -8,7 +8,7 @@ packages:
 catalog:
   '@milaboratories/ts-builder': 1.6.0
   '@milaboratories/ts-configs': 1.3.0
-  '@platforma-sdk/workflow-tengo': 6.6.5
+  '@platforma-sdk/workflow-tengo': 6.7.0
   '@platforma-sdk/model': 1.79.20
   '@platforma-sdk/ui-vue': 1.79.20
   '@platforma-sdk/tengo-builder': 4.0.11

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -13,7 +13,7 @@ catalog:
   '@platforma-sdk/ui-vue': 1.79.20
   '@platforma-sdk/tengo-builder': 4.0.11
   '@platforma-sdk/package-builder': 3.14.0
-  '@platforma-sdk/block-tools': 2.11.5
+  '@platforma-sdk/block-tools': 2.12.0
 
   '@platforma-sdk/test': 1.79.22
   '@milaboratories/helpers': 1.14.2

--- a/workflow/src/mixcr-analyze.tpl.tengo
+++ b/workflow/src/mixcr-analyze.tpl.tengo
@@ -79,10 +79,6 @@ self.body(func(inputs) {
 		env("MI_LICENSE_DEBUG", "MI_LICENSE_DEBUG").
 		arg("analyze").arg("--use-local-temp")
 
-	// CPUs number per process. cpuReq is reused below by resources({ onCPU }),
-	// which requires a cpu request alongside a RAM formula.
-	cpuReq := is_undefined(perProcessCPUs) ? 16 : perProcessCPUs // 16 = default CPUs per sample
-
 	// Memory limit per process.
 	// Size analyze RAM from the input reads' file size, on top of a per-analysis
 	// floor. size("reads") sums the stored (compressed) blob size of the sample's
@@ -96,19 +92,21 @@ self.body(func(inputs) {
 	// cannot evaluate resource formulas, the ram formula falls back to the baseline.
 
 	f := exec.formula
-	baseMemGiB := 64
 	ram := undefined
 	if !is_undefined(perProcessMemGB) {
 		// explicit "Advanced Settings" override — a static request, not a formula
 		ram = string(perProcessMemGB) + "GiB"
 	} else {
+		baseMemGiB := 64
 		if hasMiToolSteps {
 			baseMemGiB = 192
 		} else if hasAssembleContigs || hasAssembleCells {
 			baseMemGiB = 110
 		}
-		// mem = clamp(baseMemGiB + 4 * size("reads"), baseMemGiB, 256 GiB)
-		ram = f.size("reads").times(4).plus(f.gib(baseMemGiB)).between(f.gib(baseMemGiB), f.gib(256)).staticFallback(string(baseMemGiB) + "GiB")
+		// ram = between(baseMemGiB + 4 * size("reads"), baseMemGiB, 256 GiB)
+		ram = f.size("reads").times(4).plus(f.gib(baseMemGiB))
+			.between(f.gib(baseMemGiB), f.gib(256))
+			.staticFallback(string(baseMemGiB) + "GiB")
 	}
 
 	// cpu is a plain constant and ram is either a static override or a formula carrying a
@@ -116,7 +114,7 @@ self.body(func(inputs) {
 	// falls back to the baseMemGiB floor, and constant/static values are used as-is.
 	mixcrCmdBuilder.resources({
 		onCPU: {
-			cpu: cpuReq,
+			cpu: is_undefined(perProcessCPUs) ? 16 : perProcessCPUs, // 16 = default CPUs per sample,
 			ram: ram
 		}
 	})

--- a/workflow/src/mixcr-analyze.tpl.tengo
+++ b/workflow/src/mixcr-analyze.tpl.tengo
@@ -104,9 +104,9 @@ self.body(func(inputs) {
 			baseMemGiB = 110
 		}
 		// ram = between(baseMemGiB + 4 * size("reads"), baseMemGiB, 256 GiB)
-		ram = f.size("reads").times(4).plus(f.gib(baseMemGiB))
-			.between(f.gib(baseMemGiB), f.gib(256))
-			.staticFallback(string(baseMemGiB) + "GiB")
+		ram = f.size("reads").times(4).plus(f.gib(baseMemGiB)).
+			between(f.gib(baseMemGiB), f.gib(256)).
+			staticFallback(string(baseMemGiB) + "GiB")
 	}
 
 	// cpu is a plain constant and ram is either a static override or a formula carrying a

--- a/workflow/src/mixcr-analyze.tpl.tengo
+++ b/workflow/src/mixcr-analyze.tpl.tengo
@@ -82,7 +82,6 @@ self.body(func(inputs) {
 	// CPUs number per process. cpuReq is reused below by resources({ onCPU }),
 	// which requires a cpu request alongside a RAM formula.
 	cpuReq := is_undefined(perProcessCPUs) ? 16 : perProcessCPUs // 16 = default CPUs per sample
-	mixcrCmdBuilder.cpu(cpuReq)
 
 	// Memory limit per process.
 	// Size analyze RAM from the input reads' file size, on top of a per-analysis
@@ -94,28 +93,33 @@ self.body(func(inputs) {
 	// single-cell+MiTool pipelines, which need that headroom regardless of size);
 	// the linear term scales with input volume; the 256 GiB cap bounds the largest.
 	// An "Advanced Settings" memory override takes precedence; on backends that
-	// cannot evaluate resource formulas, memFormula falls back to the baseline.
-    if !is_undefined(perProcessMemGB) {
-        // memory per process was set in "Advanced Settings" block directly
-		mixcrCmdBuilder.mem(string(perProcessMemGB) + "GiB")
+	// cannot evaluate resource formulas, the ram formula falls back to the baseline.
+
+	f := exec.formula
+	baseMemGiB := 64
+	ram := undefined
+	if !is_undefined(perProcessMemGB) {
+		// explicit "Advanced Settings" override — a static request, not a formula
+		ram = string(perProcessMemGB) + "GiB"
 	} else {
-		baseMemGiB := 64
 		if hasMiToolSteps {
 			baseMemGiB = 192
 		} else if hasAssembleContigs || hasAssembleCells {
 			baseMemGiB = 110
 		}
-		f := exec.formula
-		// mem = clamp(baseMemGiB + 4 * size("reads"), baseMemGiB, 256 GiB). The new API
-		// bundles cpu + ram; on backends without getBlobSize the ram formula falls back
-		// to the baseMemGiB floor.
-		mixcrCmdBuilder.resources({
-			onCPU: {
-				cpu: cpuReq,
-				ram: f.size("reads").times(4).plus(f.gib(baseMemGiB)).between(f.gib(baseMemGiB), f.gib(256)).staticFallback(string(baseMemGiB) + "GiB")
-			}
-		})
+		// mem = clamp(baseMemGiB + 4 * size("reads"), baseMemGiB, 256 GiB)
+		ram = f.size("reads").times(4).plus(f.gib(baseMemGiB)).between(f.gib(baseMemGiB), f.gib(256)).staticFallback(string(baseMemGiB) + "GiB")
 	}
+
+	// cpu is a plain constant and ram is either a static override or a formula carrying a
+	// .staticFallback — so this resolves on backends without getBlobSize too: the formula
+	// falls back to the baseMemGiB floor, and constant/static values are used as-is.
+	mixcrCmdBuilder.resources({
+		onCPU: {
+			cpu: cpuReq,
+			ram: ram
+		}
+	})
 
 	if !is_undefined(limitInput) {
 		mixcrCmdBuilder.arg("--limit-input").arg(string(limitInput))

--- a/workflow/src/mixcr-analyze.tpl.tengo
+++ b/workflow/src/mixcr-analyze.tpl.tengo
@@ -79,12 +79,10 @@ self.body(func(inputs) {
 		env("MI_LICENSE_DEBUG", "MI_LICENSE_DEBUG").
 		arg("analyze").arg("--use-local-temp")
 
-	// CPUs number per process
-	if !is_undefined(perProcessCPUs) {
-	    mixcrCmdBuilder.cpu(perProcessCPUs)
-	} else {
-	    mixcrCmdBuilder.cpu(16)     // default CPUs number per sample
-	}
+	// CPUs number per process. cpuReq is reused below by resources({ onCPU }),
+	// which requires a cpu request alongside a RAM formula.
+	cpuReq := is_undefined(perProcessCPUs) ? 16 : perProcessCPUs // 16 = default CPUs per sample
+	mixcrCmdBuilder.cpu(cpuReq)
 
 	// Memory limit per process.
 	// Size analyze RAM from the input reads' file size, on top of a per-analysis
@@ -108,12 +106,15 @@ self.body(func(inputs) {
 			baseMemGiB = 110
 		}
 		f := exec.formula
-		mixcrCmdBuilder.memFormula(
-			f.clamp(
-				f.add(f.gib(baseMemGiB), f.mul(f.size("reads"), 4)),
-				f.gib(baseMemGiB),
-				f.gib(256)),
-			{ fallback: string(baseMemGiB) + "GiB" })
+		// mem = clamp(baseMemGiB + 4 * size("reads"), baseMemGiB, 256 GiB). The new API
+		// bundles cpu + ram; on backends without getBlobSize the ram formula falls back
+		// to the baseMemGiB floor.
+		mixcrCmdBuilder.resources({
+			onCPU: {
+				cpu: cpuReq,
+				ram: f.size("reads").times(4).plus(f.gib(baseMemGiB)).between(f.gib(baseMemGiB), f.gib(256)).staticFallback(string(baseMemGiB) + "GiB")
+			}
+		})
 	}
 
 	if !is_undefined(limitInput) {


### PR DESCRIPTION
Bumps `@platforma-sdk/workflow-tengo` `6.6.5 → 6.7.0` (fluent-only `exec.formula`) and migrates the analyze exec's RAM sizing to the new API.

- `.memFormula(f.clamp(f.add(f.gib(base), f.mul(f.size("reads"), 4)), f.gib(base), f.gib(256)), { fallback })` → `.resources({ onCPU: { cpu, ram } })` with the fluent chain `f.size("reads").times(4).plus(f.gib(base)).between(f.gib(base), f.gib(256)).staticFallback(...)`.
- **Behavior-preserving**: RAM stays `clamp(baseMemGiB + 4·size, baseMemGiB, 256 GiB)`; CPU is the same per-sample count (the new `resources({ onCPU })` requires cpu alongside a ram formula, so it's stated there).

Verified: tengo check clean, full block build passes (9/9).

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR migrates `workflow/src/mixcr-analyze.tpl.tengo` from the deprecated `.cpu()` / `.memFormula()` builder methods to the unified `.resources({ onCPU: { cpu, ram } })` fluent API introduced in `@platforma-sdk/workflow-tengo@6.7.0`, and bumps `@platforma-sdk/block-tools` to 2.12.0 alongside it.

- **RAM formula** is rewritten from `f.clamp(f.add(f.gib(base), f.mul(f.size("reads"), 4)), f.gib(base), f.gib(256))` to the equivalent `f.size("reads").times(4).plus(f.gib(base)).between(f.gib(base), f.gib(256)).staticFallback(...)` — semantics are identical (clamp to `[base, 256 GiB]`).
- **CPU** previously set in a standalone `if/else` block is now inlined as the ternary `is_undefined(perProcessCPUs) ? 16 : perProcessCPUs` inside `resources({ onCPU })`, keeping the same default of 16 cores.
- **Static override path** (`perProcessMemGB` set) passes a plain `"NNNGiB"` string directly as `ram`, which is accepted by the new API alongside formula objects.

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

The change is a mechanical API migration with behavior-preserving math; the formula, fallback, and CPU default all map 1-to-1 to the old code.

The RAM formula refactoring is mathematically equivalent and the static-override path continues to work unchanged. The only findings are cosmetic: exec.formula is bound unconditionally but only used in one branch, and a comment has a stray trailing comma. Neither affects runtime behavior.

workflow/src/mixcr-analyze.tpl.tengo — worth a quick read-through to confirm the new .resources() API shape matches what workflow-tengo 6.7.0 expects for a mixed static/formula ram value.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| workflow/src/mixcr-analyze.tpl.tengo | Migrates RAM sizing and CPU configuration from deprecated .memFormula()/.cpu() calls to the new .resources({ onCPU: { cpu, ram } }) fluent API; formula semantics are preserved; minor: f (exec.formula) is declared unconditionally but only consumed in the formula branch. |
| pnpm-workspace.yaml | Bumps @platforma-sdk/workflow-tengo 6.6.5 → 6.7.0 and @platforma-sdk/block-tools 2.11.5 → 2.12.0 in the shared catalog; straightforward version pins. |
| pnpm-lock.yaml | Lockfile updated consistently with workspace catalog changes; additional transitive dependencies introduced by block-tools 2.12.0 all pinned with integrity hashes. |
| .changeset/migrate-fluent-formula-api.md | New changeset entry accurately describes the migration as patch-level and summarises the formula equivalence. |

</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[inputs.perProcessMemGB set?] -->|Yes| B["ram = string(perProcessMemGB) + 'GiB'\n(static string)"]
    A -->|No| C{Pipeline type?}
    C -->|hasMiToolSteps| D[baseMemGiB = 192]
    C -->|hasAssembleContigs or hasAssembleCells| E[baseMemGiB = 110]
    C -->|default| F[baseMemGiB = 64]
    D & E & F --> G["ram = f.size('reads').times(4)\n  .plus(f.gib(baseMemGiB))\n  .between(f.gib(baseMemGiB), f.gib(256))\n  .staticFallback(baseMemGiB + 'GiB')"]
    B & G --> H["mixcrCmdBuilder.resources({\n  onCPU: { cpu: perProcessCPUs ?? 16, ram }\n})"]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[inputs.perProcessMemGB set?] -->|Yes| B["ram = string(perProcessMemGB) + 'GiB'\n(static string)"]
    A -->|No| C{Pipeline type?}
    C -->|hasMiToolSteps| D[baseMemGiB = 192]
    C -->|hasAssembleContigs or hasAssembleCells| E[baseMemGiB = 110]
    C -->|default| F[baseMemGiB = 64]
    D & E & F --> G["ram = f.size('reads').times(4)\n  .plus(f.gib(baseMemGiB))\n  .between(f.gib(baseMemGiB), f.gib(256))\n  .staticFallback(baseMemGiB + 'GiB')"]
    B & G --> H["mixcrCmdBuilder.resources({\n  onCPU: { cpu: perProcessCPUs ?? 16, ram }\n})"]
```

</a>
</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Aworkflow%2Fsrc%2Fmixcr-analyze.tpl.tengo%3A94-99%0AThe%20%60f%60%20variable%20%28%60exec.formula%60%29%20is%20declared%20unconditionally%20at%20the%20top%20of%20the%20block%2C%20but%20it%20is%20only%20consumed%20inside%20the%20%60else%60%20branch.%20When%20%60perProcessMemGB%60%20is%20set%20the%20variable%20is%20assigned%20and%20then%20silently%20ignored.%20While%20Tengo%20allows%20this%2C%20moving%20the%20declaration%20inside%20the%20%60else%60%20branch%20keeps%20intent%20clear%20and%20matches%20the%20old%20code's%20layout.%0A%0A%60%60%60suggestion%0A%09ram%20%3A%3D%20undefined%0A%09if%20!is_undefined%28perProcessMemGB%29%20%7B%0A%09%09%2F%2F%20explicit%20%22Advanced%20Settings%22%20override%20%E2%80%94%20a%20static%20request%2C%20not%20a%20formula%0A%09%09ram%20%3D%20string%28perProcessMemGB%29%20%2B%20%22GiB%22%0A%09%7D%20else%20%7B%0A%09%09f%20%3A%3D%20exec.formula%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%202%0Aworkflow%2Fsrc%2Fmixcr-analyze.tpl.tengo%3A117%0AStray%20trailing%20comma%20in%20the%20inline%20comment.%20It%20reads%20as%20if%20it's%20part%20of%20a%20list%20but%20there%20is%20no%20continuation%2C%20which%20can%20be%20mildly%20confusing%20during%20a%20later%20read.%0A%0A%60%60%60suggestion%0A%09%09%09cpu%3A%20is_undefined%28perProcessCPUs%29%20%3F%2016%20%3A%20perProcessCPUs%2C%20%2F%2F%2016%20%3D%20default%20CPUs%20per%20sample%0A%60%60%60%0A%0A&repo=platforma-open%2Fmixcr-clonotyping&pr=199&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
workflow/src/mixcr-analyze.tpl.tengo:94-99
The `f` variable (`exec.formula`) is declared unconditionally at the top of the block, but it is only consumed inside the `else` branch. When `perProcessMemGB` is set the variable is assigned and then silently ignored. While Tengo allows this, moving the declaration inside the `else` branch keeps intent clear and matches the old code's layout.

```suggestion
	ram := undefined
	if !is_undefined(perProcessMemGB) {
		// explicit "Advanced Settings" override — a static request, not a formula
		ram = string(perProcessMemGB) + "GiB"
	} else {
		f := exec.formula
```

### Issue 2 of 2
workflow/src/mixcr-analyze.tpl.tengo:117
Stray trailing comma in the inline comment. It reads as if it's part of a list but there is no continuation, which can be mildly confusing during a later read.

```suggestion
			cpu: is_undefined(perProcessCPUs) ? 16 : perProcessCPUs, // 16 = default CPUs per sample
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["MILAB-6480: fix Tengo parse error — use ..."](https://github.com/platforma-open/mixcr-clonotyping/commit/c067138c8c070b1105b9d74597435d57b8ef0884) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43044381)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->