### PR TITLE
Julenmendieta/MILAB-6617_singleCellVhh

### DIFF
--- a/.changeset/few-suns-leave.md
+++ b/.changeset/few-suns-leave.md
@@ -1,0 +1,8 @@
+---
+"@platforma-open/milaboratories.mixcr-clonotyping-2.workflow": minor
+"@platforma-open/milaboratories.mixcr-clonotyping-2": minor
+"@platforma-open/milaboratories.mixcr-clonotyping-2.model": minor
+"@platforma-open/milaboratories.mixcr-clonotyping-2.ui": minor
+---
+
+Allow single-cell VHH data analysis

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -11,7 +11,7 @@ on:
   workflow_dispatch: {}
 jobs:
   init:
-    runs-on: ubuntu-latest
+    runs-on: hz-ubuntu-dind
     steps:
       - uses: milaboratory/github-ci/actions/context/init@v4
         with:
@@ -25,7 +25,9 @@ jobs:
       app-name: 'Block: Mixcr Clonotyping 2'
       app-name-slug: 'block-mixcr-clonotyping-2'
       node-version: '20.x'
-      build-script-name: 'build'
+      gha-runner-label: hz-ubuntu-dind
+      build-script-name: 'build:dev-local'
+      build-before-publish-script-name: 'build:release'
       pnpm-recursive-build: false
 
       test: true
@@ -56,6 +58,15 @@ jobs:
 
           "AWS_CI_IAM_MONOREPO_SIMPLE_ROLE": ${{ toJSON(secrets.AWS_CI_IAM_MONOREPO_SIMPLE_ROLE) }},
           "AWS_CI_TURBOREPO_S3_BUCKET": ${{ toJSON(secrets.AWS_CI_TURBOREPO_S3_BUCKET) }},
+
+          "HZ_CI_TURBO_S3_BUCKET": ${{ toJSON(vars.HZ_CI_TURBO_S3_BUCKET) }},
+          "HZ_CI_TURBO_S3_ENDPOINT": ${{ toJSON(vars.HZ_CI_TURBO_S3_ENDPOINT) }},
+          "HZ_CI_TURBO_S3_REGION": ${{ toJSON(vars.HZ_CI_TURBO_S3_REGION) }},
+          "HZ_CI_TURBO_S3_ACCESS_KEY": ${{ toJSON(secrets.HZ_CI_TURBO_S3_ACCESS_KEY) }},
+          "HZ_CI_TURBO_S3_SECRET_KEY": ${{ toJSON(secrets.HZ_CI_TURBO_S3_SECRET_KEY) }},
+          "HZ_CI_CACHE_S3_ACCESS_KEY": ${{ toJSON(secrets.HZ_CI_CACHE_S3_ACCESS_KEY) }},
+          "HZ_CI_CACHE_S3_SECRET_KEY": ${{ toJSON(secrets.HZ_CI_CACHE_S3_SECRET_KEY) }},
+
           "PL_REGISTRY_PLATFORMA_OPEN_UPLOAD_URL": ${{ toJSON(secrets.PL_REGISTRY_PLOPEN_UPLOAD_URL) }},
           "QUAY_USERNAME": ${{ toJSON(secrets.QUAY_USERNAME) }},
           "QUAY_ROBOT_TOKEN": ${{ toJSON(secrets.QUAY_ROBOT_TOKEN) }} }

--- a/.structure
+++ b/.structure
@@ -1,1 +1,1 @@
-{"version":1}
+{"version":2}

--- a/block/package.json
+++ b/block/package.json
@@ -19,7 +19,7 @@
   "scripts": {
     "build": "ts-builder build --target block-facade && block-tools pack",
     "prepublishOnly": "block-tools publish -r s3://milab-euce1-prod-pkgs-s3-block-registry/pub/releases/?region=eu-central-1 --registry-serve-url https://blocks.pl-open.science",
-    "do-pack": "pnpm pack && shx mv *.tgz package.tgz",
+    "do-pack": "shx rm -f package.tgz && pnpm pack && shx mv *.tgz package.tgz",
     "check": "ts-builder type-check --target block-facade"
   },
   "dependencies": {},

--- a/model/src/args.ts
+++ b/model/src/args.ts
@@ -55,6 +55,9 @@ const BlockArgsValidBase = z.object({
   presetCommonName: z.string().optional(),
   isGenericPreset: z.boolean().optional(),
   chains: z.array(z.string()).optional(),
+  // When true, single-cell IG data is treated as heavy-chain-only (VHH / nanobody):
+  // the light chain is not computed and clonotypes are not required to be paired.
+  scHeavyOnly: z.boolean().optional(),
   exportMinQuality: z.boolean().optional(),
   stopCodonTypes: z.array(StopCodonType).optional(),
   stopCodonReplacements: StopCodonReplacements,

--- a/model/src/index.ts
+++ b/model/src/index.ts
@@ -54,6 +54,8 @@ export const platforma = BlockModelV3.create(dataModel)
     if (!data.input) throw new Error("Input dataset is required");
     if (!data.preset) throw new Error("Preset is required");
     if (!data.chains || data.chains.length === 0) throw new Error("Chains selection is required");
+    if (data.scHeavyOnly && !(data.chains.length === 1 && data.chains[0] === "IG"))
+      throw new Error("Heavy-chain only (VHH) mode requires selecting only the IG receptor");
     if (data.runMode === "dry" && data.limitInput == null)
       throw new Error("Read limit is required for Preview mode");
     if (!BlockArgsValid.safeParse(data).success) return undefined;
@@ -63,6 +65,7 @@ export const platforma = BlockModelV3.create(dataModel)
       input: data.input,
       preset: data.preset,
       chains: data.chains,
+      scHeavyOnly: data.scHeavyOnly,
       inputLibrary: data.inputLibrary,
       libraryFile: data.libraryFile,
       isLibraryFileGzipped: data.isLibraryFileGzipped,

--- a/package.json
+++ b/package.json
@@ -1,11 +1,9 @@
 {
   "scripts": {
-    "build": "turbo run build",
-    "build:dev": "env PL_PKG_DEV=local turbo run build",
     "lint": "turbo run lint",
     "type-check": "turbo run type-check",
-    "test": "env PL_PKG_DEV=local turbo run test --concurrency 1",
-    "test:dry-run": "env PL_PKG_DEV=local turbo run test --dry-run=json",
+    "test": "env PL_BUILD_CHANNEL=dev PL_BUILD_VARIANT=binary PL_BUILD_LOCATION=local turbo run test --concurrency 1",
+    "test:dry-run": "env PL_BUILD_CHANNEL=dev PL_BUILD_VARIANT=binary PL_BUILD_LOCATION=local turbo run test --dry-run=json",
     "mark-stable": "turbo run mark-stable",
     "do-pack": "turbo run do-pack",
     "watch": "turbo watch build",
@@ -14,7 +12,12 @@
     "update-sdk": "block-tools structure refresh --update-deps-only",
     "fmt": "turbo run fmt",
     "check": "turbo run check",
-    "upgrade-sdk": "block-tools structure refresh --update-deps-only && pnpm i && block-tools structure refresh && pnpm i && pnpm fmt"
+    "upgrade-sdk": "block-tools structure refresh --update-deps-only && pnpm i && block-tools structure refresh && pnpm i && pnpm fmt",
+    "build:dev-local": "env PL_BUILD_CHANNEL=dev PL_BUILD_VARIANT=all PL_BUILD_LOCATION=local turbo run build",
+    "build:dev-remote": "env PL_BUILD_CHANNEL=dev PL_BUILD_VARIANT=all PL_BUILD_LOCATION=remote turbo run build",
+    "build:dev-no-software": "env PL_BUILD_CHANNEL=dev PL_BUILD_VARIANT=none turbo run build",
+    "build:dev-binary-existing": "env PL_BUILD_CHANNEL=dev PL_BUILD_USE_PUBLISHED=true turbo run build",
+    "build:release": "env PL_BUILD_CHANNEL=release PL_BUILD_VARIANT=all PL_BUILD_LOCATION=remote turbo run build"
   },
   "devDependencies": {
     "@changesets/cli": "catalog:",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,8 +10,8 @@ catalogs:
       specifier: ^2.29.7
       version: 2.29.8
     '@milaboratories/helpers':
-      specifier: 1.14.2
-      version: 1.14.2
+      specifier: 1.14.3
+      version: 1.14.3
     '@milaboratories/ts-builder':
       specifier: 1.6.0
       version: 1.6.0
@@ -25,23 +25,23 @@ catalogs:
       specifier: 4.7.0-347-develop
       version: 4.7.0-347-develop
     '@platforma-sdk/block-tools':
-      specifier: 2.11.5
-      version: 2.11.5
+      specifier: 2.12.4
+      version: 2.12.4
     '@platforma-sdk/model':
-      specifier: 1.79.20
-      version: 1.79.20
+      specifier: 1.79.27
+      version: 1.79.27
     '@platforma-sdk/tengo-builder':
-      specifier: 4.0.11
-      version: 4.0.11
+      specifier: 4.0.16
+      version: 4.0.16
     '@platforma-sdk/test':
-      specifier: 1.79.22
-      version: 1.79.22
+      specifier: 1.79.34
+      version: 1.79.34
     '@platforma-sdk/ui-vue':
-      specifier: 1.79.20
-      version: 1.79.20
+      specifier: 1.79.34
+      version: 1.79.34
     '@platforma-sdk/workflow-tengo':
-      specifier: 6.6.5
-      version: 6.6.5
+      specifier: 6.7.1
+      version: 6.7.1
     '@types/wicg-file-system-access':
       specifier: ^2023.10.7
       version: 2023.10.7
@@ -104,7 +104,7 @@ importers:
         version: 1.6.0(@types/node@24.10.2)(rollup@4.53.3)(vue@3.5.25(typescript@5.6.3))(yaml@2.8.2)
       '@platforma-sdk/block-tools':
         specifier: 'catalog:'
-        version: 2.11.5(@types/node@24.10.2)
+        version: 2.12.4(@types/node@24.10.2)
       js-yaml:
         specifier: 'catalog:'
         version: 4.1.1
@@ -137,10 +137,10 @@ importers:
         version: link:../workflow
       '@platforma-sdk/block-tools':
         specifier: 'catalog:'
-        version: 2.11.5(@types/node@24.10.2)
+        version: 2.12.4(@types/node@24.10.2)
       '@platforma-sdk/model':
         specifier: 'catalog:'
-        version: 1.79.20
+        version: 1.79.27
       shx:
         specifier: 'catalog:'
         version: 0.4.0
@@ -152,10 +152,10 @@ importers:
     dependencies:
       '@milaboratories/helpers':
         specifier: 'catalog:'
-        version: 1.14.2
+        version: 1.14.3
       '@platforma-sdk/model':
         specifier: 'catalog:'
-        version: 1.79.20
+        version: 1.79.27
       typescript:
         specifier: '*'
         version: 5.9.3
@@ -171,7 +171,7 @@ importers:
         version: 1.3.0
       '@platforma-sdk/block-tools':
         specifier: 'catalog:'
-        version: 2.11.5(@types/node@24.10.2)
+        version: 2.12.4(@types/node@24.10.2)
       '@types/node':
         specifier: '*'
         version: 24.10.2
@@ -192,7 +192,7 @@ importers:
         version: 1.18.0
       '@platforma-sdk/model':
         specifier: 'catalog:'
-        version: 1.79.20
+        version: 1.79.27
       this-block:
         specifier: workspace:@platforma-open/milaboratories.mixcr-clonotyping-2@*
         version: link:../block
@@ -208,7 +208,7 @@ importers:
         version: 1.3.0
       '@platforma-sdk/test':
         specifier: 'catalog:'
-        version: 1.79.22(@bytecodealliance/preview2-shim@0.17.9)(@types/node@24.10.2)(vite@8.0.7(@types/node@24.10.2)(yaml@2.8.2))
+        version: 1.79.34(@bytecodealliance/preview2-shim@0.17.9)(@types/node@24.10.2)(vite@8.0.7(@types/node@24.10.2)(yaml@2.8.2))
       eslint:
         specifier: 'catalog:'
         version: 9.39.1
@@ -220,16 +220,16 @@ importers:
     dependencies:
       '@milaboratories/helpers':
         specifier: 'catalog:'
-        version: 1.14.2
+        version: 1.14.3
       '@platforma-open/milaboratories.mixcr-clonotyping-2.model':
         specifier: workspace:*
         version: link:../model
       '@platforma-sdk/model':
         specifier: 'catalog:'
-        version: 1.79.20
+        version: 1.79.27
       '@platforma-sdk/ui-vue':
         specifier: 'catalog:'
-        version: 1.79.20(@bytecodealliance/preview2-shim@0.17.9)(typescript@5.9.3)
+        version: 1.79.34(@bytecodealliance/preview2-shim@0.17.9)(typescript@5.9.3)
       '@types/node':
         specifier: '*'
         version: 24.10.2
@@ -278,14 +278,14 @@ importers:
         version: 4.7.0-347-develop
       '@platforma-sdk/workflow-tengo':
         specifier: 'catalog:'
-        version: 6.6.5
+        version: 6.7.1
     devDependencies:
       '@platforma-sdk/tengo-builder':
         specifier: 'catalog:'
-        version: 4.0.11
+        version: 4.0.16
       '@platforma-sdk/test':
         specifier: 'catalog:'
-        version: 1.79.22(@bytecodealliance/preview2-shim@0.17.9)(@types/node@24.10.2)(vite@8.0.7(@types/node@24.10.2)(yaml@2.8.2))
+        version: 1.79.34(@bytecodealliance/preview2-shim@0.17.9)(@types/node@24.10.2)(vite@8.0.7(@types/node@24.10.2)(yaml@2.8.2))
       shx:
         specifier: 'catalog:'
         version: 0.4.0
@@ -376,6 +376,10 @@ packages:
   '@aws-crypto/util@5.2.0':
     resolution: {integrity: sha512-4RkU9EsI6ZpBve5fseQlGNUWKMa1RLPQ1dnjnQoe07ldfIzcsGb5hC5W0Dm7u423KWzawlrpbjXBrXCEv9zazQ==}
 
+  '@aws-sdk/client-ecr-public@3.859.0':
+    resolution: {integrity: sha512-pPY85lrGBNWynofNC6Er49W6aA4JvOOKC9RDbS8rWR8pBPEG6p0B82VQKFMR+3JYRogpfQf5hzU47um96EslFA==}
+    engines: {node: '>=18.0.0'}
+
   '@aws-sdk/client-s3@3.859.0':
     resolution: {integrity: sha512-oFLHZX1X6o54ZlweubtSVvQDz15JiNrgDD7KeMZT2MwxiI3axPcHzTo2uizjj5mgNapmYjRmQS5c1c63dvruVA==}
     engines: {node: '>=18.0.0'}
@@ -415,6 +419,12 @@ packages:
   '@aws-sdk/credential-provider-web-identity@3.858.0':
     resolution: {integrity: sha512-8iULWsH83iZDdUuiDsRb83M0NqIlXjlDbJUIddVsIrfWp4NmanKw77SV6yOZ66nuJjPsn9j7RDb9bfEPCy5SWA==}
     engines: {node: '>=18.0.0'}
+
+  '@aws-sdk/lib-storage@3.859.0':
+    resolution: {integrity: sha512-VfaEhih4MMxD6llibXEnrS4HyExhLpIFAvy1nq490IGO/Z6JCI81kmA3rB376XahMhoS9CVN0eAoeryTYHFHGw==}
+    engines: {node: '>=18.0.0'}
+    peerDependencies:
+      '@aws-sdk/client-s3': ^3.859.0
 
   '@aws-sdk/middleware-bucket-endpoint@3.840.0':
     resolution: {integrity: sha512-+gkQNtPwcSMmlwBHFd4saVVS11In6ID1HczNzpM3MXKXRBfSlbZJbCt6wN//AZ8HMklZEik4tcEOG0qa9UY8SQ==}
@@ -1116,20 +1126,24 @@ packages:
   '@microsoft/tsdoc@0.16.0':
     resolution: {integrity: sha512-xgAyonlVVS+q7Vc7qLW0UrJU7rSFcETRWsqdXZtjzRU8dF+6CkozTK4V4y1LwOX7j8r/vHphjDeMeGI4tNGeGA==}
 
-  '@milaboratories/computable@2.9.5':
-    resolution: {integrity: sha512-rzLJ6fjXcNL8jb6vexGR4d8wUGvrwC2CyjkMLU5GFy+7Q6lg1wTrJnu8fzDVhS2OjEEVbD+RTE7AGvK5pYYSMQ==}
+  '@milaboratories/computable@2.9.6':
+    resolution: {integrity: sha512-Au+84jboSJMM2k39mWUFCtPl2wkislD1fLbb45du1PcAg1GSER1ThSLoBpZUQC2oiTt804WmbzhZ2yaoVZiVLQ==}
     engines: {node: '>=22.19.0'}
 
   '@milaboratories/helpers@1.14.2':
     resolution: {integrity: sha512-zOkD4aWNbembwI+AsPTz7nmWC1VPA4rwGBc+Nd5jPpKVh7rCtZwQrlOP5mVqRVMKIAjb1nU8kzzCGfqNPqfJjA==}
     engines: {node: '>=22'}
 
-  '@milaboratories/pf-driver@1.7.14':
-    resolution: {integrity: sha512-JRuMmuhObyD27MtpCcimGklr2yMJ2PobcYJ2y5k+UuhQWXKllhEDlUAyv2Xw/I7Xxym8Nn2npcVdOaJvTP3bPA==}
+  '@milaboratories/helpers@1.14.3':
+    resolution: {integrity: sha512-nZv+n+orVzA/GimDTNj6Yjb52+Wu5f/Kf2z6UCGXni6KTquLBfQhi3AFB1mLE7hkUYPvKU6LxuRY02CQMQiTVA==}
+    engines: {node: '>=22'}
+
+  '@milaboratories/pf-driver@1.7.16':
+    resolution: {integrity: sha512-yujIUylT11CwM4alKVETxTnXQpcKHH1x5hZIAKTni/Q98JHs+teewNhUwpaWACwjuEhmF3EYSTgTXeUoeI9hAg==}
     engines: {node: '>=22.19.0'}
 
-  '@milaboratories/pf-spec-driver@1.4.16':
-    resolution: {integrity: sha512-x6SQVUU3fl+1fFavCSzc1DNMB08HKoo0PT5dpXJWAi6oEw77yueoe1StZJVY0Kgj1BpVhlmuuC87PJu8s4eFRw==}
+  '@milaboratories/pf-spec-driver@1.4.18':
+    resolution: {integrity: sha512-lXaoSyGCWUlrYZaoyRIWWT0Hpx9DWODXI7VdraNjYnCofJpYKMdAZW3sfCE9kdVup8ic29vywNPLeTjrVQ24sg==}
 
   '@milaboratories/pframes-rs-node@1.1.52':
     resolution: {integrity: sha512-Uu4KsQx0GiKvFASI+Cm0nMCMieUVo35mpz4j8mYUYImr7S+bVDDcHweCWrkLkSeImnOQnYHVo9RycViG6QwUQw==}
@@ -1148,56 +1162,59 @@ packages:
       '@milaboratories/pl-model-common': 1.46.2
       '@milaboratories/pl-model-middle-layer': 1.30.7
 
-  '@milaboratories/pl-client@3.12.0':
-    resolution: {integrity: sha512-uca6tbW7hy7H/Sf010/9HNQMFKwf6bJ/JONyNgvQB+hGdJZb//vjw0xoBQDun0wSAkPm+9H2I+e0q6RUfcNZng==}
+  '@milaboratories/pl-client@3.14.0':
+    resolution: {integrity: sha512-WpKN8u71VAIJ6uYAdZqNe3/Ob73noxw7GW8JFZoIMqGVLwvTAbVyffjKuuH4V9S/hA+OXpv7/Dfxqpph5eAVYg==}
     engines: {node: '>=22.19.0'}
 
-  '@milaboratories/pl-config@1.8.2':
-    resolution: {integrity: sha512-FG9rlAKDf1rwlg+3G9OG2bCKISNp6ajM27W7ODDSsWE4MSCVxhYB172UusbohY2RDmaD9GI5pDKO5O9uoHQCCA==}
+  '@milaboratories/pl-config@1.8.3':
+    resolution: {integrity: sha512-JPIWG/9q7SL9QSYUhHwF9MCfGbpJyo2KxaO9IE2gEvy+oiGw1oBJvNdthC9V/uW2jHp/Qov9+x7LveHzN+bfeA==}
 
-  '@milaboratories/pl-deployments@3.0.8':
-    resolution: {integrity: sha512-7WvA761yI7eLCdJE19uNa/a6fLxytVrKJ/utBJ6GelZQFuA/LT12VkG6r0uAFtU8afY9Sr89078oLzZSZJR/oA==}
+  '@milaboratories/pl-deployments@3.0.10':
+    resolution: {integrity: sha512-AEFI5gRH1quEUZPqV4wkYabVevpTRGMJXPILsYGh/In9eSw56aHIl8pHoZP5h8v3J5v//KNU7aP8sYANh8S7rA==}
     engines: {node: '>=22.19.0'}
 
-  '@milaboratories/pl-drivers@1.16.3':
-    resolution: {integrity: sha512-/HObfG0uuFDYUd8G3qxlhrvhvTo8T5MH42+Vpr8snN+YnSHGyMXo6rw6oKRNO+h/GF+kbI5DTr9kNsQVEwyFng==}
+  '@milaboratories/pl-drivers@1.16.8':
+    resolution: {integrity: sha512-w8K++36KQZkDIkVz5Wk/TXBT8h+KG99eMpWjo3Esq9tK+8v9ZiswTBNuG99Wtg3vdBAaJfqf4iqeblSwZk8QcQ==}
     engines: {node: '>=22'}
 
   '@milaboratories/pl-error-like@1.12.10':
     resolution: {integrity: sha512-iHmnLG5lxJqcymUmEL8onCDGEADk1S/5RNACQ5yfTCNcCkUc+7hYrDHQpFmWXPPGC9sG+NTBxt4wr5m8UsLm2g==}
 
-  '@milaboratories/pl-errors@1.4.24':
-    resolution: {integrity: sha512-pV0oF0zO6bwAo/llQlu4Q00uI0guPQ9Wn+coK3pwLrateKidVRH/2XhwUgTwgS8vDECBNCgtYR6E/Im+nl+FMw==}
+  '@milaboratories/pl-errors@1.4.29':
+    resolution: {integrity: sha512-j1iyOgoUlyk4/HvfhRfzvYRxkN4p01XjmFtdlTu8YdRQRp7goNZXtzTOMFAvltocb+ZeRjEOxIW5+3dsbXsFmA==}
 
-  '@milaboratories/pl-healthcheck@1.0.1':
-    resolution: {integrity: sha512-eiYd/TFm18SW4EY8vkI3c+fcPnjUu3Hd1GnPLWCN8U+dNmp/tnrzfeCgaY4xO/s0vkHNX9E7IrsQiMg2Ioz4rw==}
+  '@milaboratories/pl-healthcheck@1.0.2':
+    resolution: {integrity: sha512-IBXQOSgJj7T/dw26AXBsR1ZaOpoqxZtSFZVPE2TonT0VaLKH4XqMFa3C+fKV1aECqbI45dBRQl/X70CUdGPWgQ==}
     engines: {node: '>=22.19.0'}
 
   '@milaboratories/pl-http@1.2.4':
     resolution: {integrity: sha512-QKmhx+WEvJCV9dUy/SBdQk/ApaJ5ewBFgm/b+XPlS10SusAdqUUTGvK5+hq8YSuUMXlHb/dk++UtI5YlDuDl2Q==}
 
-  '@milaboratories/pl-middle-layer@1.64.40':
-    resolution: {integrity: sha512-d71/T3zlTtunFgVum28FLhlZuKuwpT591B2ZfZVO6Jamd8nY54CxcBmIsIG4xVTqitvsQhNFiAJdkoYgXE6Inw==}
+  '@milaboratories/pl-middle-layer@1.65.9':
+    resolution: {integrity: sha512-ICbmXZRskk2RSRqthxtBzzkS1Jyc8ccUAHoxV3BplbCtzOS9M+QcebPFg+pCRE6cEDJG+DlMCTOUNL4k6MX5HQ==}
     engines: {node: '>=22.19.0'}
 
-  '@milaboratories/pl-model-backend@1.4.9':
-    resolution: {integrity: sha512-84+Pv2RhonE/ZwR5bXipOGK4cC5V3C4vmhzIgc8TWpgLxUNsjCjoodSo3bzPcpA+URShTf4+3h4C28O/wO/MCw==}
+  '@milaboratories/pl-model-backend@1.4.14':
+    resolution: {integrity: sha512-8hn28/D59y3914PJXaOX2B5HBOYplaBhyvKPhsOjlAUhNATa9QBMMqVmYW5ZUJ8m8zZJJvOUVS8FShBMQQbjFA==}
 
   '@milaboratories/pl-model-common@1.46.2':
     resolution: {integrity: sha512-VEeauisApYScvCS8lnK3zpFJ520xuTAodKJmjR8ulHcMrWMyWMfHEdGb7j5OMD0mM/OwTgmQrrJ5eB7Xd+xoOQ==}
 
+  '@milaboratories/pl-model-common@1.46.4':
+    resolution: {integrity: sha512-QArgLyQkf8kHSQquxStyk5Xfnau8S4M2vKEbUVQRRoZCzLU1lcDVXRwGgAzRH5NizeqYNrB/wt0/tShajH+6eA==}
+
+  '@milaboratories/pl-model-middle-layer@1.30.11':
+    resolution: {integrity: sha512-yFThwVqOTb2gJw/tp4PkZcsKI7yRRJCX3QuA6fIc2+tNxCqyEQmdpLmaIY/nhaziIp9ByBT9MrzWNIQd1T9aww==}
+
   '@milaboratories/pl-model-middle-layer@1.30.7':
     resolution: {integrity: sha512-rs9x3Ron4ujR/UOdEgB8WUB1SvZ8ZAScT1Av/e4or+iiQ/CzhmK9nqtYamHVwKV+JgwIFbXQwxGvIHDVz955dQ==}
 
-  '@milaboratories/pl-model-middle-layer@1.30.9':
-    resolution: {integrity: sha512-fnrCjWPR0HeytWC3rnHkY3bpNk3UOuED+lwmauhYBKRaF46cV1df46clJSkGNZHS9g439SYwclW4no2X/ALaFQ==}
-
-  '@milaboratories/pl-tree@1.12.14':
-    resolution: {integrity: sha512-G6uUG+3b4rH0eEQP6B31unFJtxsutETJckvapqXd9u+Uo906mK4w5u6DnXcNWfhWhKx3/hp8v89CsYSDO3b7Qw==}
+  '@milaboratories/pl-tree@1.12.19':
+    resolution: {integrity: sha512-Mod4gxBFgpBrLYqB6qIhUolQRrU+PvPgpj2auP3G6KF6GExy2GkZkJ3XX4fKd3sXLWsBim3ISidmA7YWp3Zezw==}
     engines: {node: '>=22.19.0'}
 
-  '@milaboratories/ptabler-expression-js@1.2.31':
-    resolution: {integrity: sha512-VB3fxuVqc0Beb+3/ge9uZ39uU8YqAhck9pTIxTpNZ5hOfMtPGJEI98YxoJQ8BuYhyyx5SM5qMU04NNs/vdk46A==}
+  '@milaboratories/ptabler-expression-js@1.2.33':
+    resolution: {integrity: sha512-ThB7tc0nPACE7b8cSoA0+zRVZfZHOCAcFioFDi207G5prgrIc/z2zbInjD0PRnWFHO7xOsfbWCkNRDqCmut6zQ==}
 
   '@milaboratories/resolve-helper@1.1.3':
     resolution: {integrity: sha512-38/dW/XRZQREOxAOOKtO0lzEWPCP/DH0qhB3q1kYcGoN++5V92/zbVwbYrMDeDcjTyo+D62iIep+sKXeWHa7Uw==}
@@ -1217,12 +1234,12 @@ packages:
   '@milaboratories/ts-configs@1.3.0':
     resolution: {integrity: sha512-6rZaMOJotG+v6eXoupHgPqxArpNBNl0f7sd5K+kUo1PUhPTe632eLJtEeBbFtwDGNYqL9QUacd4pT5t6oDOf0A==}
 
-  '@milaboratories/ts-helpers@1.8.3':
-    resolution: {integrity: sha512-HK3AmNZl2fOzMHot2+ihKsOC+fluwhl5261VTn1zGS3LRpmC9bCk/po8SzsVmg79ccI5nESFTdz+BRaLsXncmQ==}
+  '@milaboratories/ts-helpers@1.8.4':
+    resolution: {integrity: sha512-YdOyANkJjFiEZgS3bfbludDo9PWOQZQ8AhGw/rpO5/7bgQ9RIVOOTAtP5/UppANoeUiYhCgJt/xvIZgnQ/PZ0w==}
     engines: {node: '>=22.19.0'}
 
-  '@milaboratories/uikit@2.15.11':
-    resolution: {integrity: sha512-oBQiPXpHEwg1dLptfCQNtpRrJ3stunjrTWiP5U90rAXl4c6Z/Ks7YU/fVvoqdBsoSBQ6nEcAG0Sk4sV8DVRlJQ==}
+  '@milaboratories/uikit@2.15.14':
+    resolution: {integrity: sha512-alefttXyF4j1h1riJMJypgalcVSQ1KFHD2P4r6kOe2uPrrI7CjpBrrn6GCqUmLmvRe/mz8eNFvoyiZBo4pe5BQ==}
 
   '@napi-rs/wasm-runtime@1.1.3':
     resolution: {integrity: sha512-xK9sGVbJWYb08+mTJt3/YV24WxvxpXcXtP6B172paPZ+Ts69Re9dAr7lKwJoeIx8OoeuimEiRZ7umkiUVClmmQ==}
@@ -1577,14 +1594,14 @@ packages:
   '@platforma-open/milaboratories.software-mixcr@4.7.0-347-develop':
     resolution: {integrity: sha512-4GlZWEhs2CxZu9GjswUA8dT0VD5M6x1pxa3iz1AgkrFx3deDHt0pJQcazJuAE0Pgm4GcyRX9p/Yf0TRmexbcmQ==}
 
-  '@platforma-open/milaboratories.software-ptabler.schema@1.15.15':
-    resolution: {integrity: sha512-zvPuRZgQyxjED+txJVgWHUOPeRp4TG1jOrJOtuw9WnwxFiHNjQHIB+Xe1j8f6skgMqZgRSQvEbhRvqbWjGmhKQ==}
+  '@platforma-open/milaboratories.software-ptabler.schema@1.15.17':
+    resolution: {integrity: sha512-Qf4QpFY8bWVtEeQphWGZ67dUaXYVWSFm/AL1ErzdOYhilnDSon2Cya6K2Fkj0TxEGBLMBxOudF/kmTw728/Pag==}
 
-  '@platforma-open/milaboratories.software-ptabler@2.1.3':
-    resolution: {integrity: sha512-4cikdkdJ5WYc0Nw3IoZxzlFNKvG1qCAqSjypq5b18pIK6LBDayzhFcuw5TDd8O3bAFhoHP+3cVTmoO9XUTYMRg==}
+  '@platforma-open/milaboratories.software-ptabler@2.1.5':
+    resolution: {integrity: sha512-bZgDa+KJyAgKKu/Ka+Hzh7thZU/PkmupMRUvXV1ruLdJoxvIcyOj9ehQuVi5DapX4sE7iQ5EkavqpK59z0oZ8w==}
 
-  '@platforma-open/milaboratories.software-ptexter@1.2.2':
-    resolution: {integrity: sha512-I08YpKQ4+esLrfpVra5UJ+bznI9Zzba6OW0rKK407a1EUmanvYMVrCbM9gqnm6CHbv2vQxNGSaO8p1LoBh+9gA==}
+  '@platforma-open/milaboratories.software-ptexter@1.2.3':
+    resolution: {integrity: sha512-5wwzvPko/tjkm6EnirsnjB+MO5mF//tgJplI+jPh3bcSHpEdHF+B9xg+S1owAnekqbimMrFZWqHSVY9ZmIHOjw==}
 
   '@platforma-open/milaboratories.software-small-binaries.hello-world-py@1.0.10':
     resolution: {integrity: sha512-16BGRLIrsVW+YIaXwWLX6Nbm80PS5mQJEclHhjNbRrRTLHPaKI4RygZfBC0lLNzvHBiTXU4Qkh1+WmdovkshDg==}
@@ -1604,30 +1621,33 @@ packages:
   '@platforma-open/milaboratories.software-small-binaries@2.1.1':
     resolution: {integrity: sha512-KN1PR7YgUUfx1dxh/TtcoWpSZbOXbRxXzQuJ505qHuXuE0spYwC7bXnvJsEYbEwRcPMa0foTrjBnPNORE4yr+Q==}
 
-  '@platforma-sdk/block-tools@2.11.5':
-    resolution: {integrity: sha512-dM4KLiJLz3zQgJfJklq9M8/Q5yTIiaDLZ2ui1o0fsKoe3wB+cGA0VJCNAjjgLeKmvZd6zqd+2OmXpCn5pOBn+g==}
+  '@platforma-sdk/block-tools@2.12.4':
+    resolution: {integrity: sha512-qIXBByWh/UjSm26GzU0pHldS3/tkT84ijsWKROT7Zq3zFbdJ/7AFCxduqReC51/+z/kLsrvjyhJUNvLozBye0A==}
     hasBin: true
 
   '@platforma-sdk/blocks-deps-updater@2.2.0':
     resolution: {integrity: sha512-p9lBxhFXM9WoRsrJO7dfkiXSK+1m63yIn1sKhBO71eMbhrLMyVYHEOeNf3w5OCdbRF5QsNhXzWuiTmFK3zHFsA==}
     hasBin: true
 
-  '@platforma-sdk/model@1.79.20':
-    resolution: {integrity: sha512-0ULETzwgo4E5rIddn/PoCAY5gSv9luDYAaSp66b8u3u1XTh43k7fgOpobu/rrfHJMiY9IGfzALDlo6jtvMLUyQ==}
+  '@platforma-sdk/model@1.79.27':
+    resolution: {integrity: sha512-Z5WYpClTZoBtvfGsiDPNlRCxPKtUF04TV3MmL1Kfb6xAb04B5NdiqWMnqw+v78Kue/y9FKTmxrCcX9lwZgYFlw==}
 
-  '@platforma-sdk/tengo-builder@4.0.11':
-    resolution: {integrity: sha512-c0LuiR7vtclto853Q1O+j8g109ooIZKtEl5tqRHG6dN/kk6S+J7DZHCpAjFuZ9pt3x6jF95sNaJEtP8uFs1uXw==}
+  '@platforma-sdk/package-builder-lib@1.2.0':
+    resolution: {integrity: sha512-AtSzaZ39BGlqcyYtpGREDz+YlGCDdSTQJNV/+NkTyUtoq1ECRO+iMqAX1DSSza1WqylnURX8vKVI2owS/cxntA==}
+
+  '@platforma-sdk/tengo-builder@4.0.16':
+    resolution: {integrity: sha512-08z5kIB5ZnSmvMPu3rcyGxh+yKyQ6fn6tYzq37kK+iLpXrB23fjgOAjqIF6NEq/Dkxr2dWSUa4BXa8XPBc0+SQ==}
     engines: {node: '>=22'}
     hasBin: true
 
-  '@platforma-sdk/test@1.79.22':
-    resolution: {integrity: sha512-So8pT0S0+bDmLHdhPPmHRz3cDdNeghDybL3dfbMKittrKF27WD6FaUqFOV96CtPpo4/bhDnZ8wL4ZUdXKChynA==}
+  '@platforma-sdk/test@1.79.34':
+    resolution: {integrity: sha512-Vo+krqfnpnI2IE3Nkbc8HOYGSqf/tp/mbuPCj/6V02WB6/LzyXWsjfp4ZbTkt+75UqSm3blNfeyi8piNg6QWJA==}
 
-  '@platforma-sdk/ui-vue@1.79.20':
-    resolution: {integrity: sha512-VwBG8MKV1M2KMR2PgW+o6uxJJRCFGihaRsnkzLL8HGKM/Vr9k3FY/V929B1XAhU5y9wb1g7fKNJvy9JNEq5GiQ==}
+  '@platforma-sdk/ui-vue@1.79.34':
+    resolution: {integrity: sha512-n2u4sjtVFh5amrIXiLQ0LA8OlJdtQ+ZMAr8aqSacxfHkBSUR1my5TVOSxfZ6xA8Huief2T4ERsEeJAqyLS7v+w==}
 
-  '@platforma-sdk/workflow-tengo@6.6.5':
-    resolution: {integrity: sha512-BIY0DongPruQ7e2EMYy2b0UtO5ziGcLvr2RWgJ8ki17VKNzW3esm/RBszGHMrTYmXM0Yw7mCSasor4vH560g7A==}
+  '@platforma-sdk/workflow-tengo@6.7.1':
+    resolution: {integrity: sha512-8vAXzDzDZpHncMHSuTjesuD/tOWWRhWyQIr8jH2MBgWJGkUXUtoDLBqYk6l5knHrYfrorDzXjsnsFQCzU0bI1A==}
 
   '@protobuf-ts/grpc-transport@2.11.1':
     resolution: {integrity: sha512-l6wrcFffY+tuNnuyrNCkRM8hDIsAZVLA8Mn7PKdVyYxITosYh60qW663p9kL6TWXYuDCL3oxH8ih3vLKTDyhtg==}
@@ -2550,6 +2570,10 @@ packages:
     resolution: {integrity: sha512-AO2ac6pjRB3SJmGJo+v5/aK6Omggp6fsLrs6wN9bd35ulu4cCwaAU9+7ZhXjeqHVkaHThLuzH0nZr0YpCDhygg==}
     engines: {node: ^18.17.0 || >=20.5.0}
 
+  abort-controller@3.0.0:
+    resolution: {integrity: sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==}
+    engines: {node: '>=6.5'}
+
   acorn-jsx@5.3.2:
     resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}
     peerDependencies:
@@ -2640,6 +2664,14 @@ packages:
   ansi-styles@6.2.3:
     resolution: {integrity: sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==}
     engines: {node: '>=12'}
+
+  archiver-utils@5.0.2:
+    resolution: {integrity: sha512-wuLJMmIBQYCsGZgYLTy5FIB2pF6Lfb6cXMSF8Qywwk3t20zWnAi7zLcQFdKQmIB8wyZpY5ER38x08GbwtR2cLA==}
+    engines: {node: '>= 14'}
+
+  archiver@7.0.1:
+    resolution: {integrity: sha512-ZcbTaIqJOfCc03QwD468Unz/5Ir8ATtvAHsK+FdXbDIbGfihqh9mrvdcYunQzqn4HrvWWaFyaxJhGZagaJJpPQ==}
+    engines: {node: '>= 14'}
 
   argparse@1.0.10:
     resolution: {integrity: sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==}
@@ -2779,11 +2811,21 @@ packages:
   buffer-crc32@0.2.13:
     resolution: {integrity: sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==}
 
+  buffer-crc32@1.0.0:
+    resolution: {integrity: sha512-Db1SbgBS/fg/392AblrMJk97KggmvYhr4pB5ZIMTWtaivCPMWLkmb7m21cJvpvgK+J3nsU2CmmixNBZx4vFj/w==}
+    engines: {node: '>=8.0.0'}
+
   buffer-fill@1.0.0:
     resolution: {integrity: sha512-T7zexNBwiiaCOGDg9xNX9PBmjrubblRkENuptryuI64URkXDFum9il/JGL8Lm8wYfAXpredVXXZz7eMHilimiQ==}
 
+  buffer@5.6.0:
+    resolution: {integrity: sha512-/gDYp/UtU0eA1ys8bOs9J6a+E/KWIY+DZ+Q2WESNUA0jFRsJOc0SNUO6xJ5SGA1xueg3NL65W6s+NY5l9cunuw==}
+
   buffer@5.7.1:
     resolution: {integrity: sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==}
+
+  buffer@6.0.3:
+    resolution: {integrity: sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==}
 
   buildcheck@0.0.7:
     resolution: {integrity: sha512-lHblz4ahamxpTmnsk+MNTRWsjYKv965MwOrSJyeD588rR3Jcu7swE+0wN5F+PbL5cjgu/9ObkhfzEPuofEMwLA==}
@@ -2890,6 +2932,10 @@ packages:
   compare-versions@6.1.1:
     resolution: {integrity: sha512-4hm4VPpIecmlg59CHXnRDnqGplJFrbLG4aFEl5vl6cK1u76ws3LLvX7ikFnTDl5vo39sjWD6AaDPYodJp/NNHg==}
 
+  compress-commons@6.0.2:
+    resolution: {integrity: sha512-6FqVXeETqWPoGcfzrXb37E50NP0LXT8kAMu5ooZayhWWdgEY4lBEEcbQNXtkuKQsGduxiIcI4gOTsxTmuq/bSg==}
+    engines: {node: '>= 14'}
+
   concat-map@0.0.1:
     resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
 
@@ -2915,6 +2961,15 @@ packages:
   cpu-features@0.0.10:
     resolution: {integrity: sha512-9IkYqtX3YHPCzoVg1Py+o9057a3i0fp7S530UWokCSaFVTc7CwXPRiOjRjBQQ18ZCNafx78YfnG+HALxtVmOGA==}
     engines: {node: '>=10.0.0'}
+
+  crc-32@1.2.2:
+    resolution: {integrity: sha512-ROmzCKrTnOwybPcJApAA6WBWij23HVfGVNKqqrZpuyZOHqK2CwHSvpGuyt/UNNvaIjEd8X5IFGp4Mh+Ie1IHJQ==}
+    engines: {node: '>=0.8'}
+    hasBin: true
+
+  crc32-stream@6.0.0:
+    resolution: {integrity: sha512-piICUB6ei4IlTv1+653yq5+KoqfBYmj9bw6LqXoOneTMDXk5nM1qt12mFW1caG3LlJXEKW1Bp0WggEmIfQB34g==}
+    engines: {node: '>= 14'}
 
   cross-spawn@6.0.6:
     resolution: {integrity: sha512-VqCUuhcd1iB+dsv8gxPttb5iZh/D0iubSP21g36KXdEuf6I5JiioesUVjpCdHV9MZRUfVFlvwtIUyPfxo5trtw==}
@@ -3161,8 +3216,16 @@ packages:
     resolution: {integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==}
     engines: {node: '>=0.10.0'}
 
+  event-target-shim@5.0.1:
+    resolution: {integrity: sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==}
+    engines: {node: '>=6'}
+
   events-universal@1.0.1:
     resolution: {integrity: sha512-LUd5euvbMLpwOF8m6ivPCbhQeSiYVNb8Vs0fQ8QjXo0JTkEHpz8pxdQf0gStltaPpw0Cca8b39KxvK9cfKRiAw==}
+
+  events@3.3.0:
+    resolution: {integrity: sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==}
+    engines: {node: '>=0.8.x'}
 
   execa@1.0.0:
     resolution: {integrity: sha512-adbxcyWV46qiHyvSp50TKt05tB4tK3HcmF7/nxfAdhnox83seTDbwnaqKO4sXRy7roHAIFqJP/Rw/AuEbX61LA==}
@@ -3584,6 +3647,10 @@ packages:
   kuler@2.0.0:
     resolution: {integrity: sha512-Xq9nH7KlWZmXAtodXDDRE7vs6DU1gTU8zYDHDiWLSip45Egwq3plLHzPn27NgvzL2r1LMPC1vdqh98sQxtqj4A==}
 
+  lazystream@1.0.1:
+    resolution: {integrity: sha512-b94GiNHQNy6JNTrt5w6zNyffMrNkXZb3KTkCZJb2V1xaEGCk093vkZ2jk3tpaeP33/OiXC+WvK9AxUebnf5nbw==}
+    engines: {node: '>= 0.6.3'}
+
   levn@0.4.1:
     resolution: {integrity: sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==}
     engines: {node: '>= 0.8.0'}
@@ -3752,6 +3819,10 @@ packages:
   minimatch@3.1.2:
     resolution: {integrity: sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==}
 
+  minimatch@5.1.9:
+    resolution: {integrity: sha512-7o1wEA2RyMP7Iu7GNba9vc0RWWGACJOCZBJX2GJWip0ikV+wcOsgVuY9uE8CPiyQhkGFSlhuSkZPavN7u1c2Fw==}
+    engines: {node: '>=10'}
+
   minimatch@9.0.1:
     resolution: {integrity: sha512-0jWhJpD/MdhPXwPuiRkCbfYfSKp2qnn2eOc279qI7f+osl/l+prKSrvhg157zSYvx/1nmgn2NqdT6k2Z7zSH9w==}
     engines: {node: '>=16 || 14 >=14.17'}
@@ -3833,6 +3904,10 @@ packages:
     resolution: {integrity: sha512-ieGu42u/Qsa4TFktmaKEwM6MQH0pOWnaB3htzh0JRtx84+Mebc0cbZYN5bC+6WTZ4+77xrL9Pn5m7CV6VIkV7A==}
     engines: {node: ^18.17.0 || >=20.5.0}
     hasBin: true
+
+  normalize-path@3.0.0:
+    resolution: {integrity: sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==}
+    engines: {node: '>=0.10.0'}
 
   npm-run-path@2.0.2:
     resolution: {integrity: sha512-lJxZYlT4DW/bRUtFh1MQIWqmLwQfAxnqWG4HhEdjMlkrJYnJn0Jrr2u3mgxqaWsdiBc76TYkTG/mhrnYTuzfHw==}
@@ -4046,6 +4121,10 @@ packages:
   process-nextick-args@2.0.1:
     resolution: {integrity: sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==}
 
+  process@0.11.10:
+    resolution: {integrity: sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==}
+    engines: {node: '>= 0.6.0'}
+
   proto-list@1.2.4:
     resolution: {integrity: sha512-vtK/94akxsTMhe0/cbfpR+syPuszcuwhqVjJq26CuNDgFGj682oRBXOP5MJpv2r7JtE8MsiepGIqvvOTBwn2vA==}
 
@@ -4094,6 +4173,13 @@ packages:
   readable-stream@3.6.2:
     resolution: {integrity: sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==}
     engines: {node: '>= 6'}
+
+  readable-stream@4.7.0:
+    resolution: {integrity: sha512-oIGGmcpTLwPga8Bn6/Z75SVaH1z5dUut2ibSyAMVhmUggWpmDn2dapB0n7f8nwaSiRtepAsfJyfXIO5DCVAODg==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+
+  readdir-glob@1.1.3:
+    resolution: {integrity: sha512-v05I2k7xN8zXvPD9N+z/uhXPaj0sUFCe2rcWZIpBsqxfP7xXFQ0tipAd/wjj1YxWyWtUS5IDJpOG82JKt2EAVA==}
 
   rechoir@0.6.2:
     resolution: {integrity: sha512-HFM8rkZ+i3zrV+4LQjwQ0W+ez98pApMGM3HUrN04j3CqzPOzl9nmP15Y8YXNm8QHGv/eacOVEjqhmWpkRV0NAw==}
@@ -4305,6 +4391,9 @@ packages:
 
   std-env@4.0.0:
     resolution: {integrity: sha512-zUMPtQ/HBY3/50VbpkupYHbRroTRZJPRLvreamgErJVys0ceuzMkD44J/QjqhHjOzK42GQ3QZIeFG1OYfOtKqQ==}
+
+  stream-browserify@3.0.0:
+    resolution: {integrity: sha512-H73RAHsVBapbim0tU2JwwOiXUj+fikfiaoYAKHF3VJfA0pe2BCzkhAHBlLG6REzE+2WNZcxOXjK7lkso+9euLA==}
 
   streamx@2.23.0:
     resolution: {integrity: sha512-kn+e44esVfn2Fa/O0CPFcex27fjIL6MkVae0Mm6q+E6f0hWv578YCERbv+4m02cjxvDsPKLnmxral/rR6lBMAg==}
@@ -4878,6 +4967,10 @@ packages:
     resolution: {integrity: sha512-U/PBtDf35ff0D8X8D0jfdzHYEPFxAI7jJlxZXwCSez5M3190m+QobIfh+sWDWSHMCWWJN2AWamkegn6vr6YBTw==}
     engines: {node: '>=18'}
 
+  zip-stream@6.0.1:
+    resolution: {integrity: sha512-zK7YHHz4ZXpW89AHXUPbQVGKI7uvkd3hzusTdotCg1UxyaVtg0zFJSTfW/Dq5f7OBBVnq6cZIaC8Ti4hb6dtCA==}
+    engines: {node: '>= 14'}
+
   zod@3.25.76:
     resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
 
@@ -4968,6 +5061,50 @@ snapshots:
       '@aws-sdk/types': 3.840.0
       '@smithy/util-utf8': 2.3.0
       tslib: 2.8.1
+
+  '@aws-sdk/client-ecr-public@3.859.0':
+    dependencies:
+      '@aws-crypto/sha256-browser': 5.2.0
+      '@aws-crypto/sha256-js': 5.2.0
+      '@aws-sdk/core': 3.858.0
+      '@aws-sdk/credential-provider-node': 3.859.0
+      '@aws-sdk/middleware-host-header': 3.840.0
+      '@aws-sdk/middleware-logger': 3.840.0
+      '@aws-sdk/middleware-recursion-detection': 3.840.0
+      '@aws-sdk/middleware-user-agent': 3.858.0
+      '@aws-sdk/region-config-resolver': 3.840.0
+      '@aws-sdk/types': 3.840.0
+      '@aws-sdk/util-endpoints': 3.848.0
+      '@aws-sdk/util-user-agent-browser': 3.840.0
+      '@aws-sdk/util-user-agent-node': 3.858.0
+      '@smithy/config-resolver': 4.4.3
+      '@smithy/core': 3.18.7
+      '@smithy/fetch-http-handler': 5.3.6
+      '@smithy/hash-node': 4.2.5
+      '@smithy/invalid-dependency': 4.2.5
+      '@smithy/middleware-content-length': 4.2.5
+      '@smithy/middleware-endpoint': 4.3.14
+      '@smithy/middleware-retry': 4.4.14
+      '@smithy/middleware-serde': 4.2.6
+      '@smithy/middleware-stack': 4.2.5
+      '@smithy/node-config-provider': 4.3.5
+      '@smithy/node-http-handler': 4.4.5
+      '@smithy/protocol-http': 5.3.5
+      '@smithy/smithy-client': 4.9.10
+      '@smithy/types': 4.9.0
+      '@smithy/url-parser': 4.2.5
+      '@smithy/util-base64': 4.3.0
+      '@smithy/util-body-length-browser': 4.2.0
+      '@smithy/util-body-length-node': 4.2.1
+      '@smithy/util-defaults-mode-browser': 4.3.13
+      '@smithy/util-defaults-mode-node': 4.2.16
+      '@smithy/util-endpoints': 3.2.5
+      '@smithy/util-middleware': 4.2.5
+      '@smithy/util-retry': 4.2.5
+      '@smithy/util-utf8': 4.2.0
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - aws-crt
 
   '@aws-sdk/client-s3@3.859.0':
     dependencies:
@@ -5181,6 +5318,17 @@ snapshots:
       tslib: 2.8.1
     transitivePeerDependencies:
       - aws-crt
+
+  '@aws-sdk/lib-storage@3.859.0(@aws-sdk/client-s3@3.859.0)':
+    dependencies:
+      '@aws-sdk/client-s3': 3.859.0
+      '@smithy/abort-controller': 4.2.5
+      '@smithy/middleware-endpoint': 4.3.14
+      '@smithy/smithy-client': 4.9.10
+      buffer: 5.6.0
+      events: 3.3.0
+      stream-browserify: 3.0.0
+      tslib: 2.8.1
 
   '@aws-sdk/middleware-bucket-endpoint@3.840.0':
     dependencies:
@@ -6105,23 +6253,25 @@ snapshots:
 
   '@microsoft/tsdoc@0.16.0': {}
 
-  '@milaboratories/computable@2.9.5':
+  '@milaboratories/computable@2.9.6':
     dependencies:
       '@milaboratories/pl-error-like': 1.12.10
-      '@milaboratories/ts-helpers': 1.8.3
+      '@milaboratories/ts-helpers': 1.8.4
       '@types/node': 24.5.2
       utility-types: 3.11.0
 
   '@milaboratories/helpers@1.14.2': {}
 
-  '@milaboratories/pf-driver@1.7.14(@bytecodealliance/preview2-shim@0.17.9)':
+  '@milaboratories/helpers@1.14.3': {}
+
+  '@milaboratories/pf-driver@1.7.16(@bytecodealliance/preview2-shim@0.17.9)':
     dependencies:
-      '@milaboratories/helpers': 1.14.2
+      '@milaboratories/helpers': 1.14.3
       '@milaboratories/pframes-rs-node': 1.1.52
-      '@milaboratories/pframes-rs-wasm': 1.1.52(@bytecodealliance/preview2-shim@0.17.9)(@milaboratories/pl-model-common@1.46.2)(@milaboratories/pl-model-middle-layer@1.30.9)
-      '@milaboratories/pl-model-common': 1.46.2
-      '@milaboratories/pl-model-middle-layer': 1.30.9
-      '@milaboratories/ts-helpers': 1.8.3
+      '@milaboratories/pframes-rs-wasm': 1.1.52(@bytecodealliance/preview2-shim@0.17.9)(@milaboratories/pl-model-common@1.46.4)(@milaboratories/pl-model-middle-layer@1.30.11)
+      '@milaboratories/pl-model-common': 1.46.4
+      '@milaboratories/pl-model-middle-layer': 1.30.11
+      '@milaboratories/ts-helpers': 1.8.4
       es-toolkit: 1.42.0
       lru-cache: 11.2.4
     transitivePeerDependencies:
@@ -6129,12 +6279,12 @@ snapshots:
       - encoding
       - supports-color
 
-  '@milaboratories/pf-spec-driver@1.4.16(@bytecodealliance/preview2-shim@0.17.9)':
+  '@milaboratories/pf-spec-driver@1.4.18(@bytecodealliance/preview2-shim@0.17.9)':
     dependencies:
-      '@milaboratories/helpers': 1.14.2
-      '@milaboratories/pframes-rs-wasm': 1.1.52(@bytecodealliance/preview2-shim@0.17.9)(@milaboratories/pl-model-common@1.46.2)(@milaboratories/pl-model-middle-layer@1.30.9)
-      '@milaboratories/pl-model-common': 1.46.2
-      '@milaboratories/pl-model-middle-layer': 1.30.9
+      '@milaboratories/helpers': 1.14.3
+      '@milaboratories/pframes-rs-wasm': 1.1.52(@bytecodealliance/preview2-shim@0.17.9)(@milaboratories/pl-model-common@1.46.4)(@milaboratories/pl-model-middle-layer@1.30.11)
+      '@milaboratories/pl-model-common': 1.46.4
+      '@milaboratories/pl-model-middle-layer': 1.30.11
       '@noble/hashes': 2.0.1
     transitivePeerDependencies:
       - '@bytecodealliance/preview2-shim'
@@ -6161,19 +6311,19 @@ snapshots:
 
   '@milaboratories/pframes-rs-wasip2@1.1.52': {}
 
-  '@milaboratories/pframes-rs-wasm@1.1.52(@bytecodealliance/preview2-shim@0.17.9)(@milaboratories/pl-model-common@1.46.2)(@milaboratories/pl-model-middle-layer@1.30.9)':
+  '@milaboratories/pframes-rs-wasm@1.1.52(@bytecodealliance/preview2-shim@0.17.9)(@milaboratories/pl-model-common@1.46.4)(@milaboratories/pl-model-middle-layer@1.30.11)':
     dependencies:
       '@bytecodealliance/preview2-shim': 0.17.9
       '@milaboratories/pframes-rs-wasip2': 1.1.52
-      '@milaboratories/pl-model-common': 1.46.2
-      '@milaboratories/pl-model-middle-layer': 1.30.9
+      '@milaboratories/pl-model-common': 1.46.4
+      '@milaboratories/pl-model-middle-layer': 1.30.11
 
-  '@milaboratories/pl-client@3.12.0':
+  '@milaboratories/pl-client@3.14.0':
     dependencies:
       '@grpc/grpc-js': 1.13.4
       '@milaboratories/pl-http': 1.2.4
-      '@milaboratories/pl-model-common': 1.46.2
-      '@milaboratories/ts-helpers': 1.8.3
+      '@milaboratories/pl-model-common': 1.46.4
+      '@milaboratories/ts-helpers': 1.8.4
       '@protobuf-ts/grpc-transport': 2.11.1(@grpc/grpc-js@1.13.4)
       '@protobuf-ts/runtime': 2.11.1
       '@protobuf-ts/runtime-rpc': 2.11.1
@@ -6186,19 +6336,19 @@ snapshots:
       utility-types: 3.11.0
       yaml: 2.8.2
 
-  '@milaboratories/pl-config@1.8.2':
+  '@milaboratories/pl-config@1.8.3':
     dependencies:
-      '@milaboratories/ts-helpers': 1.8.3
+      '@milaboratories/ts-helpers': 1.8.4
       upath: 2.0.1
       yaml: 2.8.2
 
-  '@milaboratories/pl-deployments@3.0.8':
+  '@milaboratories/pl-deployments@3.0.10':
     dependencies:
-      '@milaboratories/pl-config': 1.8.2
-      '@milaboratories/pl-healthcheck': 1.0.1
+      '@milaboratories/pl-config': 1.8.3
+      '@milaboratories/pl-healthcheck': 1.0.2
       '@milaboratories/pl-http': 1.2.4
-      '@milaboratories/pl-model-common': 1.46.2
-      '@milaboratories/ts-helpers': 1.8.3
+      '@milaboratories/pl-model-common': 1.46.4
+      '@milaboratories/ts-helpers': 1.8.4
       decompress: 4.2.1
       ssh2: 1.17.0
       tar: 7.5.2
@@ -6207,15 +6357,15 @@ snapshots:
       yaml: 2.8.2
       zod: 3.25.76
 
-  '@milaboratories/pl-drivers@1.16.3':
+  '@milaboratories/pl-drivers@1.16.8':
     dependencies:
       '@grpc/grpc-js': 1.13.4
-      '@milaboratories/computable': 2.9.5
-      '@milaboratories/helpers': 1.14.2
-      '@milaboratories/pl-client': 3.12.0
-      '@milaboratories/pl-model-common': 1.46.2
-      '@milaboratories/pl-tree': 1.12.14
-      '@milaboratories/ts-helpers': 1.8.3
+      '@milaboratories/computable': 2.9.6
+      '@milaboratories/helpers': 1.14.3
+      '@milaboratories/pl-client': 3.14.0
+      '@milaboratories/pl-model-common': 1.46.4
+      '@milaboratories/pl-tree': 1.12.19
+      '@milaboratories/ts-helpers': 1.8.4
       '@protobuf-ts/grpc-transport': 2.11.1(@grpc/grpc-js@1.13.4)
       '@protobuf-ts/plugin': 2.11.1
       '@protobuf-ts/runtime': 2.11.1
@@ -6238,16 +6388,16 @@ snapshots:
       json-stringify-safe: 5.0.1
       zod: 3.25.76
 
-  '@milaboratories/pl-errors@1.4.24':
+  '@milaboratories/pl-errors@1.4.29':
     dependencies:
-      '@milaboratories/pl-client': 3.12.0
-      '@milaboratories/ts-helpers': 1.8.3
+      '@milaboratories/pl-client': 3.14.0
+      '@milaboratories/ts-helpers': 1.8.4
       zod: 3.25.76
 
-  '@milaboratories/pl-healthcheck@1.0.1':
+  '@milaboratories/pl-healthcheck@1.0.2':
     dependencies:
       '@grpc/grpc-js': 1.13.4
-      '@milaboratories/ts-helpers': 1.8.3
+      '@milaboratories/ts-helpers': 1.8.4
       '@protobuf-ts/grpc-transport': 2.11.1(@grpc/grpc-js@1.13.4)
       '@protobuf-ts/runtime': 2.11.1
       '@protobuf-ts/runtime-rpc': 2.11.1
@@ -6256,28 +6406,28 @@ snapshots:
     dependencies:
       undici: 7.16.0
 
-  '@milaboratories/pl-middle-layer@1.64.40(@bytecodealliance/preview2-shim@0.17.9)(@types/node@24.10.2)':
+  '@milaboratories/pl-middle-layer@1.65.9(@bytecodealliance/preview2-shim@0.17.9)(@types/node@24.10.2)':
     dependencies:
-      '@milaboratories/computable': 2.9.5
-      '@milaboratories/helpers': 1.14.2
-      '@milaboratories/pf-driver': 1.7.14(@bytecodealliance/preview2-shim@0.17.9)
-      '@milaboratories/pf-spec-driver': 1.4.16(@bytecodealliance/preview2-shim@0.17.9)
+      '@milaboratories/computable': 2.9.6
+      '@milaboratories/helpers': 1.14.3
+      '@milaboratories/pf-driver': 1.7.16(@bytecodealliance/preview2-shim@0.17.9)
+      '@milaboratories/pf-spec-driver': 1.4.18(@bytecodealliance/preview2-shim@0.17.9)
       '@milaboratories/pframes-rs-node': 1.1.52
-      '@milaboratories/pframes-rs-wasm': 1.1.52(@bytecodealliance/preview2-shim@0.17.9)(@milaboratories/pl-model-common@1.46.2)(@milaboratories/pl-model-middle-layer@1.30.9)
-      '@milaboratories/pl-client': 3.12.0
-      '@milaboratories/pl-deployments': 3.0.8
-      '@milaboratories/pl-drivers': 1.16.3
-      '@milaboratories/pl-errors': 1.4.24
+      '@milaboratories/pframes-rs-wasm': 1.1.52(@bytecodealliance/preview2-shim@0.17.9)(@milaboratories/pl-model-common@1.46.4)(@milaboratories/pl-model-middle-layer@1.30.11)
+      '@milaboratories/pl-client': 3.14.0
+      '@milaboratories/pl-deployments': 3.0.10
+      '@milaboratories/pl-drivers': 1.16.8
+      '@milaboratories/pl-errors': 1.4.29
       '@milaboratories/pl-http': 1.2.4
-      '@milaboratories/pl-model-backend': 1.4.9
-      '@milaboratories/pl-model-common': 1.46.2
-      '@milaboratories/pl-model-middle-layer': 1.30.9
-      '@milaboratories/pl-tree': 1.12.14
+      '@milaboratories/pl-model-backend': 1.4.14
+      '@milaboratories/pl-model-common': 1.46.4
+      '@milaboratories/pl-model-middle-layer': 1.30.11
+      '@milaboratories/pl-tree': 1.12.19
       '@milaboratories/resolve-helper': 1.1.3
-      '@milaboratories/ts-helpers': 1.8.3
-      '@platforma-sdk/block-tools': 2.11.5(@types/node@24.10.2)
-      '@platforma-sdk/model': 1.79.20
-      '@platforma-sdk/workflow-tengo': 6.6.5
+      '@milaboratories/ts-helpers': 1.8.4
+      '@platforma-sdk/block-tools': 2.12.4(@types/node@24.10.2)
+      '@platforma-sdk/model': 1.79.27
+      '@platforma-sdk/workflow-tengo': 6.7.1
       canonicalize: 2.1.0
       denque: 2.1.0
       es-toolkit: 1.42.0
@@ -6298,9 +6448,9 @@ snapshots:
       - react-native-b4a
       - supports-color
 
-  '@milaboratories/pl-model-backend@1.4.9':
+  '@milaboratories/pl-model-backend@1.4.14':
     dependencies:
-      '@milaboratories/pl-client': 3.12.0
+      '@milaboratories/pl-client': 3.14.0
       canonicalize: 2.1.0
       zod: 3.25.76
 
@@ -6311,6 +6461,21 @@ snapshots:
       canonicalize: 2.1.0
       zod: 3.25.76
 
+  '@milaboratories/pl-model-common@1.46.4':
+    dependencies:
+      '@milaboratories/helpers': 1.14.3
+      '@milaboratories/pl-error-like': 1.12.10
+      canonicalize: 2.1.0
+      zod: 3.25.76
+
+  '@milaboratories/pl-model-middle-layer@1.30.11':
+    dependencies:
+      '@milaboratories/helpers': 1.14.3
+      '@milaboratories/pl-model-common': 1.46.4
+      es-toolkit: 1.42.0
+      utility-types: 3.11.0
+      zod: 3.25.76
+
   '@milaboratories/pl-model-middle-layer@1.30.7':
     dependencies:
       '@milaboratories/helpers': 1.14.2
@@ -6319,27 +6484,19 @@ snapshots:
       utility-types: 3.11.0
       zod: 3.25.76
 
-  '@milaboratories/pl-model-middle-layer@1.30.9':
+  '@milaboratories/pl-tree@1.12.19':
     dependencies:
-      '@milaboratories/helpers': 1.14.2
-      '@milaboratories/pl-model-common': 1.46.2
-      es-toolkit: 1.42.0
-      utility-types: 3.11.0
-      zod: 3.25.76
-
-  '@milaboratories/pl-tree@1.12.14':
-    dependencies:
-      '@milaboratories/computable': 2.9.5
-      '@milaboratories/pl-client': 3.12.0
-      '@milaboratories/pl-errors': 1.4.24
-      '@milaboratories/ts-helpers': 1.8.3
+      '@milaboratories/computable': 2.9.6
+      '@milaboratories/pl-client': 3.14.0
+      '@milaboratories/pl-errors': 1.4.29
+      '@milaboratories/ts-helpers': 1.8.4
       denque: 2.1.0
       utility-types: 3.11.0
       zod: 3.25.76
 
-  '@milaboratories/ptabler-expression-js@1.2.31':
+  '@milaboratories/ptabler-expression-js@1.2.33':
     dependencies:
-      '@platforma-open/milaboratories.software-ptabler.schema': 1.15.15
+      '@platforma-open/milaboratories.software-ptabler.schema': 1.15.17
 
   '@milaboratories/resolve-helper@1.1.3': {}
 
@@ -6472,16 +6629,16 @@ snapshots:
 
   '@milaboratories/ts-configs@1.3.0': {}
 
-  '@milaboratories/ts-helpers@1.8.3':
+  '@milaboratories/ts-helpers@1.8.4':
     dependencies:
-      '@milaboratories/helpers': 1.14.2
+      '@milaboratories/helpers': 1.14.3
       canonicalize: 2.1.0
       denque: 2.1.0
 
-  '@milaboratories/uikit@2.15.11(typescript@5.9.3)':
+  '@milaboratories/uikit@2.15.14(typescript@5.9.3)':
     dependencies:
-      '@milaboratories/helpers': 1.14.2
-      '@platforma-sdk/model': 1.79.20
+      '@milaboratories/helpers': 1.14.3
+      '@platforma-sdk/model': 1.79.27
       '@types/d3-array': 3.2.2
       '@types/d3-axis': 3.0.6
       '@types/d3-scale': 4.0.9
@@ -6783,13 +6940,13 @@ snapshots:
 
   '@platforma-open/milaboratories.software-mixcr@4.7.0-347-develop': {}
 
-  '@platforma-open/milaboratories.software-ptabler.schema@1.15.15':
+  '@platforma-open/milaboratories.software-ptabler.schema@1.15.17':
     dependencies:
-      '@milaboratories/pl-model-common': 1.46.2
+      '@milaboratories/pl-model-common': 1.46.4
 
-  '@platforma-open/milaboratories.software-ptabler@2.1.3': {}
+  '@platforma-open/milaboratories.software-ptabler@2.1.5': {}
 
-  '@platforma-open/milaboratories.software-ptexter@1.2.2': {}
+  '@platforma-open/milaboratories.software-ptexter@1.2.3': {}
 
   '@platforma-open/milaboratories.software-small-binaries.hello-world-py@1.0.10': {}
 
@@ -6809,17 +6966,19 @@ snapshots:
       '@platforma-open/milaboratories.software-small-binaries.mnz-client': 1.6.5
       '@platforma-open/milaboratories.software-small-binaries.table-converter': 1.3.5
 
-  '@platforma-sdk/block-tools@2.11.5(@types/node@24.10.2)':
+  '@platforma-sdk/block-tools@2.12.4(@types/node@24.10.2)':
     dependencies:
+      '@aws-sdk/client-ecr-public': 3.859.0
       '@aws-sdk/client-s3': 3.859.0
       '@inquirer/prompts': 7.10.1(@types/node@24.10.2)
       '@milaboratories/pl-http': 1.2.4
-      '@milaboratories/pl-model-backend': 1.4.9
-      '@milaboratories/pl-model-common': 1.46.2
-      '@milaboratories/pl-model-middle-layer': 1.30.9
+      '@milaboratories/pl-model-backend': 1.4.14
+      '@milaboratories/pl-model-common': 1.46.4
+      '@milaboratories/pl-model-middle-layer': 1.30.11
       '@milaboratories/resolve-helper': 1.1.3
-      '@milaboratories/ts-helpers': 1.8.3
+      '@milaboratories/ts-helpers': 1.8.4
       '@platforma-sdk/blocks-deps-updater': 2.2.0
+      '@platforma-sdk/package-builder-lib': 1.2.0
       canonicalize: 2.1.0
       commander: 15.0.0
       lru-cache: 11.2.4
@@ -6831,40 +6990,57 @@ snapshots:
     transitivePeerDependencies:
       - '@types/node'
       - aws-crt
+      - bare-abort-controller
+      - react-native-b4a
 
   '@platforma-sdk/blocks-deps-updater@2.2.0':
     dependencies:
       yaml: 2.8.2
 
-  '@platforma-sdk/model@1.79.20':
+  '@platforma-sdk/model@1.79.27':
     dependencies:
-      '@milaboratories/helpers': 1.14.2
+      '@milaboratories/helpers': 1.14.3
       '@milaboratories/pl-error-like': 1.12.10
-      '@milaboratories/pl-model-common': 1.46.2
-      '@milaboratories/pl-model-middle-layer': 1.30.9
-      '@milaboratories/ptabler-expression-js': 1.2.31
+      '@milaboratories/pl-model-common': 1.46.4
+      '@milaboratories/pl-model-middle-layer': 1.30.11
+      '@milaboratories/ptabler-expression-js': 1.2.33
       canonicalize: 2.1.0
       es-toolkit: 1.42.0
       fast-json-patch: 3.1.1
       utility-types: 3.11.0
       zod: 3.25.76
 
-  '@platforma-sdk/tengo-builder@4.0.11':
+  '@platforma-sdk/package-builder-lib@1.2.0':
     dependencies:
-      '@milaboratories/pl-model-backend': 1.4.9
+      '@aws-sdk/client-s3': 3.859.0
+      '@aws-sdk/lib-storage': 3.859.0(@aws-sdk/client-s3@3.859.0)
+      '@milaboratories/resolve-helper': 1.1.3
+      archiver: 7.0.1
+      undici: 7.16.0
+      winston: 3.19.0
+      yaml: 2.8.2
+      zod: 3.25.76
+    transitivePeerDependencies:
+      - aws-crt
+      - bare-abort-controller
+      - react-native-b4a
+
+  '@platforma-sdk/tengo-builder@4.0.16':
+    dependencies:
+      '@milaboratories/pl-model-backend': 1.4.14
       '@milaboratories/resolve-helper': 1.1.3
       '@milaboratories/tengo-tester': 1.6.4
-      '@milaboratories/ts-helpers': 1.8.3
+      '@milaboratories/ts-helpers': 1.8.4
       commander: 15.0.0
       winston: 3.19.0
 
-  '@platforma-sdk/test@1.79.22(@bytecodealliance/preview2-shim@0.17.9)(@types/node@24.10.2)(vite@8.0.7(@types/node@24.10.2)(yaml@2.8.2))':
+  '@platforma-sdk/test@1.79.34(@bytecodealliance/preview2-shim@0.17.9)(@types/node@24.10.2)(vite@8.0.7(@types/node@24.10.2)(yaml@2.8.2))':
     dependencies:
-      '@milaboratories/computable': 2.9.5
-      '@milaboratories/pl-client': 3.12.0
-      '@milaboratories/pl-middle-layer': 1.64.40(@bytecodealliance/preview2-shim@0.17.9)(@types/node@24.10.2)
-      '@milaboratories/pl-tree': 1.12.14
-      '@platforma-sdk/model': 1.79.20
+      '@milaboratories/computable': 2.9.6
+      '@milaboratories/pl-client': 3.14.0
+      '@milaboratories/pl-middle-layer': 1.65.9(@bytecodealliance/preview2-shim@0.17.9)(@types/node@24.10.2)
+      '@milaboratories/pl-tree': 1.12.19
+      '@platforma-sdk/model': 1.79.27
       '@vitest/coverage-istanbul': 4.1.3(vitest@4.1.3)
       vitest: 4.1.3(@types/node@24.10.2)(@vitest/coverage-istanbul@4.1.3(vitest@4.0.18(@types/node@24.10.2)(lightningcss@1.32.0)(yaml@2.8.2)))(vite@8.0.7(@types/node@24.10.2)(yaml@2.8.2))
     transitivePeerDependencies:
@@ -6888,12 +7064,12 @@ snapshots:
       - supports-color
       - vite
 
-  '@platforma-sdk/ui-vue@1.79.20(@bytecodealliance/preview2-shim@0.17.9)(typescript@5.9.3)':
+  '@platforma-sdk/ui-vue@1.79.34(@bytecodealliance/preview2-shim@0.17.9)(typescript@5.9.3)':
     dependencies:
-      '@milaboratories/pf-spec-driver': 1.4.16(@bytecodealliance/preview2-shim@0.17.9)
-      '@milaboratories/pl-model-common': 1.46.2
-      '@milaboratories/uikit': 2.15.11(typescript@5.9.3)
-      '@platforma-sdk/model': 1.79.20
+      '@milaboratories/pf-spec-driver': 1.4.18(@bytecodealliance/preview2-shim@0.17.9)
+      '@milaboratories/pl-model-common': 1.46.4
+      '@milaboratories/uikit': 2.15.14(typescript@5.9.3)
+      '@platforma-sdk/model': 1.79.27
       '@types/d3-format': 3.0.4
       '@types/node': 24.5.2
       '@types/semver': 7.7.1
@@ -6924,12 +7100,12 @@ snapshots:
       - typescript
       - universal-cookie
 
-  '@platforma-sdk/workflow-tengo@6.6.5':
+  '@platforma-sdk/workflow-tengo@6.7.1':
     dependencies:
       '@milaboratories/pframes-rs-wasip2': 1.1.52
       '@milaboratories/software-pframes-conv': 2.2.9
-      '@platforma-open/milaboratories.software-ptabler': 2.1.3
-      '@platforma-open/milaboratories.software-ptexter': 1.2.2
+      '@platforma-open/milaboratories.software-ptabler': 2.1.5
+      '@platforma-open/milaboratories.software-ptexter': 1.2.3
       '@platforma-open/milaboratories.software-small-binaries': 2.1.1
 
   '@protobuf-ts/grpc-transport@2.11.1(@grpc/grpc-js@1.13.4)':
@@ -7661,7 +7837,7 @@ snapshots:
       istanbul-lib-report: 3.0.1
       istanbul-reports: 3.2.0
       magicast: 0.5.2
-      obug: 2.1.1
+      obug: 2.1.3
       tinyrainbow: 3.1.0
       vitest: 4.1.3(@types/node@24.10.2)(@vitest/coverage-istanbul@4.1.3(vitest@4.0.18(@types/node@24.10.2)(lightningcss@1.32.0)(yaml@2.8.2)))(vite@8.0.7(@types/node@24.10.2)(yaml@2.8.2))
     transitivePeerDependencies:
@@ -7933,6 +8109,10 @@ snapshots:
 
   abbrev@3.0.1: {}
 
+  abort-controller@3.0.0:
+    dependencies:
+      event-target-shim: 5.0.1
+
   acorn-jsx@5.3.2(acorn@8.15.0):
     dependencies:
       acorn: 8.15.0
@@ -8024,6 +8204,29 @@ snapshots:
       color-convert: 2.0.1
 
   ansi-styles@6.2.3: {}
+
+  archiver-utils@5.0.2:
+    dependencies:
+      glob: 10.5.0
+      graceful-fs: 4.2.11
+      is-stream: 2.0.1
+      lazystream: 1.0.1
+      lodash: 4.17.21
+      normalize-path: 3.0.0
+      readable-stream: 4.7.0
+
+  archiver@7.0.1:
+    dependencies:
+      archiver-utils: 5.0.2
+      async: 3.2.6
+      buffer-crc32: 1.0.0
+      readable-stream: 4.7.0
+      readdir-glob: 1.1.3
+      tar-stream: 3.1.7
+      zip-stream: 6.0.1
+    transitivePeerDependencies:
+      - bare-abort-controller
+      - react-native-b4a
 
   argparse@1.0.10:
     dependencies:
@@ -8164,9 +8367,21 @@ snapshots:
 
   buffer-crc32@0.2.13: {}
 
+  buffer-crc32@1.0.0: {}
+
   buffer-fill@1.0.0: {}
 
+  buffer@5.6.0:
+    dependencies:
+      base64-js: 1.5.1
+      ieee754: 1.2.1
+
   buffer@5.7.1:
+    dependencies:
+      base64-js: 1.5.1
+      ieee754: 1.2.1
+
+  buffer@6.0.3:
     dependencies:
       base64-js: 1.5.1
       ieee754: 1.2.1
@@ -8255,6 +8470,14 @@ snapshots:
 
   compare-versions@6.1.1: {}
 
+  compress-commons@6.0.2:
+    dependencies:
+      crc-32: 1.2.2
+      crc32-stream: 6.0.0
+      is-stream: 2.0.1
+      normalize-path: 3.0.0
+      readable-stream: 4.7.0
+
   concat-map@0.0.1: {}
 
   confbox@0.1.8: {}
@@ -8277,6 +8500,13 @@ snapshots:
       buildcheck: 0.0.7
       nan: 2.24.0
     optional: true
+
+  crc-32@1.2.2: {}
+
+  crc32-stream@6.0.0:
+    dependencies:
+      crc-32: 1.2.2
+      readable-stream: 4.7.0
 
   cross-spawn@6.0.6:
     dependencies:
@@ -8553,11 +8783,15 @@ snapshots:
 
   esutils@2.0.3: {}
 
+  event-target-shim@5.0.1: {}
+
   events-universal@1.0.1:
     dependencies:
       bare-events: 2.8.2
     transitivePeerDependencies:
       - bare-abort-controller
+
+  events@3.3.0: {}
 
   execa@1.0.0:
     dependencies:
@@ -8954,6 +9188,10 @@ snapshots:
 
   kuler@2.0.0: {}
 
+  lazystream@1.0.1:
+    dependencies:
+      readable-stream: 2.3.8
+
   levn@0.4.1:
     dependencies:
       prelude-ls: 1.2.1
@@ -9100,6 +9338,10 @@ snapshots:
     dependencies:
       brace-expansion: 1.1.12
 
+  minimatch@5.1.9:
+    dependencies:
+      brace-expansion: 2.0.2
+
   minimatch@9.0.1:
     dependencies:
       brace-expansion: 2.0.2
@@ -9161,6 +9403,8 @@ snapshots:
   nopt@8.1.0:
     dependencies:
       abbrev: 3.0.1
+
+  normalize-path@3.0.0: {}
 
   npm-run-path@2.0.2:
     dependencies:
@@ -9385,6 +9629,8 @@ snapshots:
 
   process-nextick-args@2.0.1: {}
 
+  process@0.11.10: {}
+
   proto-list@1.2.4: {}
 
   protobufjs@7.5.4:
@@ -9460,6 +9706,18 @@ snapshots:
       inherits: 2.0.4
       string_decoder: 1.3.0
       util-deprecate: 1.0.2
+
+  readable-stream@4.7.0:
+    dependencies:
+      abort-controller: 3.0.0
+      buffer: 6.0.3
+      events: 3.3.0
+      process: 0.11.10
+      string_decoder: 1.3.0
+
+  readdir-glob@1.1.3:
+    dependencies:
+      minimatch: 5.1.9
 
   rechoir@0.6.2:
     dependencies:
@@ -9697,6 +9955,11 @@ snapshots:
   std-env@3.10.0: {}
 
   std-env@4.0.0: {}
+
+  stream-browserify@3.0.0:
+    dependencies:
+      inherits: 2.0.4
+      readable-stream: 3.6.2
 
   streamx@2.23.0:
     dependencies:
@@ -10070,7 +10333,7 @@ snapshots:
       es-module-lexer: 2.0.0
       expect-type: 1.3.0
       magic-string: 0.30.21
-      obug: 2.1.1
+      obug: 2.1.3
       pathe: 2.0.3
       picomatch: 4.0.4
       std-env: 4.0.0
@@ -10230,5 +10493,11 @@ snapshots:
   yocto-queue@0.1.0: {}
 
   yoctocolors-cjs@2.1.3: {}
+
+  zip-stream@6.0.1:
+    dependencies:
+      archiver-utils: 5.0.2
+      compress-commons: 6.0.2
+      readable-stream: 4.7.0
 
   zod@3.25.76: {}

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -8,15 +8,15 @@ packages:
 catalog:
   '@milaboratories/ts-builder': 1.6.0
   '@milaboratories/ts-configs': 1.3.0
-  '@platforma-sdk/workflow-tengo': 6.6.5
-  '@platforma-sdk/model': 1.79.20
-  '@platforma-sdk/ui-vue': 1.79.20
-  '@platforma-sdk/tengo-builder': 4.0.11
-  '@platforma-sdk/package-builder': 3.14.0
-  '@platforma-sdk/block-tools': 2.11.5
+  '@platforma-sdk/workflow-tengo': 6.7.1
+  '@platforma-sdk/model': 1.79.27
+  '@platforma-sdk/ui-vue': 1.79.34
+  '@platforma-sdk/tengo-builder': 4.0.16
+  '@platforma-sdk/package-builder': 3.14.1
+  '@platforma-sdk/block-tools': 2.12.4
 
-  '@platforma-sdk/test': 1.79.22
-  '@milaboratories/helpers': 1.14.2
+  '@platforma-sdk/test': 1.79.34
+  '@milaboratories/helpers': 1.14.3
 
   '@platforma-open/milaboratories.software-mixcr': 4.7.0-347-develop
   'vue': 3.5.24

--- a/test/.oxfmtrc.json
+++ b/test/.oxfmtrc.json
@@ -1,4 +1,4 @@
 {
   "extends": ["node_modules/@milaboratories/ts-builder/configs/oxfmt.json"],
-  "ignorePatterns": ["dist", "coverage", "CHANGELOG.md"]
+  "ignorePatterns": ["dist", "coverage", "CHANGELOG.md", ".test_auth.json"]
 }

--- a/turbo.json
+++ b/turbo.json
@@ -12,12 +12,22 @@
     "build": {
       "dependsOn": ["^build", "check"],
       "inputs": ["$TURBO_DEFAULT$"],
-      "env": ["PL_PKG_DEV", "PL_DOCKER_REGISTRY_PUSH_TO"],
+      "env": [
+        "PL_DOCKER_REGISTRY_PUSH_TO",
+        "PL_BUILD_CHANNEL",
+        "PL_BUILD_VARIANT",
+        "PL_BUILD_LOCATION",
+        "PL_BUILD_USE_PUBLISHED",
+        "PL_DEV_DOCKER_PUSH_URL",
+        "PL_DEV_DOCKER_PULL_URL",
+        "PL_DEV_BINARY_UPLOAD_URL",
+        "PL_RELEASE_DOCKER_PUSH_URL",
+        "PL_RELEASE_DOCKER_PULL_URL",
+        "PL_RELEASE_BINARY_UPLOAD_URL",
+        "PL_REGISTRY_PLATFORMA_OPEN_UPLOAD_URL"
+      ],
+      "passThroughEnv": ["AWS_*", "PL_AWS_*"],
       "outputs": ["./dist/**", "./block-pack/**", "./pkg-*.tgz"]
-    },
-    "build:dev": {
-      "dependsOn": ["build"],
-      "outputs": ["./dist/**"]
     },
     "do-pack": {
       "dependsOn": ["build"],

--- a/ui/src/SettingsPanel.vue
+++ b/ui/src/SettingsPanel.vue
@@ -683,8 +683,8 @@ watch(stopCodonSelection, (selected) => {
       </PlTooltip>
     </PlCheckbox>
     <PlAlert v-if="scHeavyOnlyReceptorConflict" type="warn">
-      Heavy-chain only (VHH) mode supports only the IG receptor. Remove the other selected receptors
-      to run.
+      Heavy-chain-only (VHH) mode is specific to immunoglobulins (IG) — please deselect any other
+      receptors (e.g. TCR) to run the block.
     </PlAlert>
     <PlSectionSeparator>MiXCR Settings</PlSectionSeparator>
     <PlDropdown

--- a/ui/src/SettingsPanel.vue
+++ b/ui/src/SettingsPanel.vue
@@ -126,6 +126,12 @@ const isSingleCell = computed(
   () => preset.value?.analysisStages.includes("assembleCells") === true,
 );
 
+// Heavy-chain-only (VHH) applies to single-cell IG data, so the option is offered only
+// when the preset is single-cell and IG is among the selected receptors.
+const showHeavyOnly = computed(
+  () => isSingleCell.value && (app.model.data.chains ?? []).includes("IG"),
+);
+
 // Compute and sync generic preset flag: requires all except tagPattern
 const isGenericPresetComputed = computed(() => {
   const rf = preset.value?.requiredFlags as unknown as readonly string[] | undefined;
@@ -275,8 +281,12 @@ watch(isSingleCell, () => {
   if (app.model.data.runMode === "dry") {
     app.model.data.limitInput = isSingleCell.value ? DRY_RUN_READS_SC : DRY_RUN_READS_BULK;
   }
-  // Heavy-chain only (VHH) is single-cell only; clear it when leaving single-cell mode.
-  if (!isSingleCell.value && app.model.data.scHeavyOnly) {
+});
+
+// The VHH option is only offered for single-cell IG; clear a stale flag when it stops applying
+// (left single-cell, or IG deselected) so it can't silently block a later run.
+watch(showHeavyOnly, (visible) => {
+  if (!visible && app.model.data.scHeavyOnly) {
     app.model.data.scHeavyOnly = undefined;
   }
 });
@@ -542,6 +552,21 @@ watch(stopCodonSelection, (selected) => {
   >
     <template #tooltip> Restrict the analysis to certain receptor types. </template>
   </PlDropdownMulti>
+
+  <PlCheckbox v-if="showHeavyOnly" v-model="scHeavyOnly">
+    Heavy-chain only (VHH)
+    <PlTooltip class="info" position="top">
+      <template #tooltip
+        >Enable for single-cell heavy-chain-only data (e.g. VHH / nanobodies) with no light chain.
+        Clonotypes are built from the heavy chain alone and cells are not required to have a paired
+        light chain. Requires selecting only the IG receptor.</template
+      >
+    </PlTooltip>
+  </PlCheckbox>
+  <PlAlert v-if="scHeavyOnlyReceptorConflict" type="warn">
+    Heavy-chain-only (VHH) mode is specific to immunoglobulins (IG) — please deselect any other
+    receptors (e.g. TCR) to run the block.
+  </PlAlert>
   <PlDropdown
     v-if="needLeftAlignmentMode"
     v-model="app.model.data.leftAlignmentMode"
@@ -672,20 +697,6 @@ watch(stopCodonSelection, (selected) => {
   </template>
 
   <PlAccordionSection label="Advanced Settings">
-    <PlCheckbox v-if="isSingleCell" v-model="scHeavyOnly">
-      Heavy-chain only (VHH)
-      <PlTooltip class="info" position="top">
-        <template #tooltip
-          >Enable for single-cell heavy-chain-only data (e.g. VHH / nanobodies) with no light chain.
-          Clonotypes are built from the heavy chain alone and cells are not required to have a
-          paired light chain. Requires selecting only the IG receptor.</template
-        >
-      </PlTooltip>
-    </PlCheckbox>
-    <PlAlert v-if="scHeavyOnlyReceptorConflict" type="warn">
-      Heavy-chain-only (VHH) mode is specific to immunoglobulins (IG) — please deselect any other
-      receptors (e.g. TCR) to run the block.
-    </PlAlert>
     <PlSectionSeparator>MiXCR Settings</PlSectionSeparator>
     <PlDropdown
       v-model="cloneClusteringMode"

--- a/ui/src/SettingsPanel.vue
+++ b/ui/src/SettingsPanel.vue
@@ -275,6 +275,10 @@ watch(isSingleCell, () => {
   if (app.model.data.runMode === "dry") {
     app.model.data.limitInput = isSingleCell.value ? DRY_RUN_READS_SC : DRY_RUN_READS_BULK;
   }
+  // Heavy-chain only (VHH) is single-cell only; clear it when leaving single-cell mode.
+  if (!isSingleCell.value && app.model.data.scHeavyOnly) {
+    app.model.data.scHeavyOnly = undefined;
+  }
 });
 
 type LocalState = {
@@ -385,6 +389,22 @@ const imputeGermline = computed({
     app.model.data.imputeGermline = value;
   },
 });
+
+const scHeavyOnly = computed({
+  get: () => app.model.data.scHeavyOnly ?? false,
+  set: (value: boolean) => {
+    app.model.data.scHeavyOnly = value;
+  },
+});
+
+// Heavy-chain only (VHH) mode only supports the IG receptor. Warn (and block via model
+// validation) if it is enabled while any non-IG receptor is selected.
+const scHeavyOnlyReceptorConflict = computed(
+  () =>
+    isSingleCell.value &&
+    scHeavyOnly.value &&
+    (app.model.data.chains ?? []).some((c) => c !== "IG"),
+);
 
 const stopCodonOptions: ListOption<StopCodonType>[] = [
   { label: "Amber (TAG)", value: "amber" },
@@ -652,6 +672,20 @@ watch(stopCodonSelection, (selected) => {
   </template>
 
   <PlAccordionSection label="Advanced Settings">
+    <PlCheckbox v-if="isSingleCell" v-model="scHeavyOnly">
+      Heavy-chain only (VHH)
+      <PlTooltip class="info" position="top">
+        <template #tooltip
+          >Enable for single-cell heavy-chain-only data (e.g. VHH / nanobodies) with no light chain.
+          Clonotypes are built from the heavy chain alone and cells are not required to have a
+          paired light chain. Requires selecting only the IG receptor.</template
+        >
+      </PlTooltip>
+    </PlCheckbox>
+    <PlAlert v-if="scHeavyOnlyReceptorConflict" type="warn">
+      Heavy-chain only (VHH) mode supports only the IG receptor. Remove the other selected receptors
+      to run.
+    </PlAlert>
     <PlSectionSeparator>MiXCR Settings</PlSectionSeparator>
     <PlDropdown
       v-model="cloneClusteringMode"

--- a/workflow/src/export-report.tpl.tengo
+++ b/workflow/src/export-report.tpl.tengo
@@ -43,6 +43,7 @@ self.body(func(inputs) {
         }
     }
     singleCellChainTsvsData := inputs.singleCellChainTsvsData
+    scHeavyOnly := inputs.scHeavyOnly == true
 	useStopCodonReplacement := !is_undefined(stopCodonTypes) && is_array(stopCodonTypes) && len(stopCodonTypes) > 0
 	if is_undefined(stopCodonReplacements) || !is_map(stopCodonReplacements) {
 		stopCodonReplacements = {}
@@ -396,10 +397,13 @@ self.body(func(inputs) {
             // Count cells per sample across all chains (unique cellKey)
             cellsPerSample := scAll.groupBy("sampleId").agg(pt.col("cellKey").nUnique().alias("scCellsTotal"))
 
-            // Cells paired across different chains: cellKey appears in >1 distinct chain
+            // A cell is "valid" when it has at least the required number of distinct chains:
+            // 2 for paired receptors, 1 for heavy-chain-only (VHH). Encoded as an exclusive
+            // lower bound so the existing ">" comparison is reused.
+            pairMinExclusive := scHeavyOnly ? 0 : 1
             cellsPerSampleChainCounts := scAll.groupBy("sampleId", "cellKey").agg(pt.col("chain").nUnique().alias("_numChains"))
-            bothChainCells := cellsPerSampleChainCounts.filter(pt.col("_numChains").gt(1)).groupBy("sampleId").agg(pt.col("cellKey").count().alias("scCellsBothChains"))
-            pairedKeys := cellsPerSampleChainCounts.filter(pt.col("_numChains").gt(1)).select(pt.col("sampleId"), pt.col("cellKey"))
+            bothChainCells := cellsPerSampleChainCounts.filter(pt.col("_numChains").gt(pairMinExclusive)).groupBy("sampleId").agg(pt.col("cellKey").count().alias("scCellsBothChains"))
+            pairedKeys := cellsPerSampleChainCounts.filter(pt.col("_numChains").gt(pairMinExclusive)).select(pt.col("sampleId"), pt.col("cellKey"))
 
             perChainJoined = perChainJoined.join(cellsPerSample, { how: "left", on: ["sampleId"] })
             perChainJoined = perChainJoined.join(bothChainCells, { how: "left", on: ["sampleId"] })
@@ -447,9 +451,15 @@ self.body(func(inputs) {
         }
         finalDf = finalDf.withColumns(
             pt.col("exportedClonotypesPaired").fillNull(0).cast("Long").alias("totalClonotypes"),
-            pt.col("readsUsedInClonotypesNew").fillNull(0).cast("Long").alias("readsUsedInClonotypes"),
-            pt.col("exportedClonotypes").fillNull(0).cast("Long").minus(pt.col("exportedClonotypesPaired").fillNull(0).cast("Long")).alias("clonotypesDroppedUnpaired")
+            pt.col("readsUsedInClonotypesNew").fillNull(0).cast("Long").alias("readsUsedInClonotypes")
         )
+        if !scHeavyOnly {
+            // Clonotypes dropped because their cell lacked a paired chain.
+            // Not applicable in heavy-chain-only (VHH) mode (column omitted from spec).
+            finalDf = finalDf.withColumns(
+                pt.col("exportedClonotypes").fillNull(0).cast("Long").minus(pt.col("exportedClonotypesPaired").fillNull(0).cast("Long")).alias("clonotypesDroppedUnpaired")
+            )
+        }
     } else {
         finalDf = finalDf.withColumns(
             pt.col("exportedClonotypes").fillNull(0).cast("Long").alias("totalClonotypes"),
@@ -484,9 +494,10 @@ self.body(func(inputs) {
     }
 
     if isSingleCell {
-        // Keep only paired cells count and name it scCellsTotal
+        // scCellsTotal: paired mode reports cells with both chains; heavy-only (VHH) mode
+        // reports all cells carrying the single chain (the genuine unique-cell count).
         finalDf = finalDf.withColumns(
-            pt.col("scCellsBothChains").fillNull(0).cast("Long").alias("scCellsTotal")
+            (scHeavyOnly ? pt.col("scCellsTotal") : pt.col("scCellsBothChains")).fillNull(0).cast("Long").alias("scCellsTotal")
         )
     }
     
@@ -500,7 +511,7 @@ self.body(func(inputs) {
     
     tsvFile := wfResult.getFile("qc-report-processed.tsv")
 
-    qcReportColumns := qcReportColumns(hasUmi, isSingleCell, sampleIdAxisSpec, chains, cellTags, umiTags, hasAssembleCells)
+    qcReportColumns := qcReportColumns(hasUmi, isSingleCell, sampleIdAxisSpec, chains, cellTags, umiTags, hasAssembleCells, scHeavyOnly)
     reportColumnsSpec := qcReportColumns.reportColumnsSpec
 
     qcReportTable := xsv.importFile(

--- a/workflow/src/export-report.tpl.tengo
+++ b/workflow/src/export-report.tpl.tengo
@@ -402,11 +402,15 @@ self.body(func(inputs) {
             // lower bound so the existing ">" comparison is reused.
             pairMinExclusive := scHeavyOnly ? 0 : 1
             cellsPerSampleChainCounts := scAll.groupBy("sampleId", "cellKey").agg(pt.col("chain").nUnique().alias("_numChains"))
-            bothChainCells := cellsPerSampleChainCounts.filter(pt.col("_numChains").gt(pairMinExclusive)).groupBy("sampleId").agg(pt.col("cellKey").count().alias("scCellsBothChains"))
             pairedKeys := cellsPerSampleChainCounts.filter(pt.col("_numChains").gt(pairMinExclusive)).select(pt.col("sampleId"), pt.col("cellKey"))
 
             perChainJoined = perChainJoined.join(cellsPerSample, { how: "left", on: ["sampleId"] })
-            perChainJoined = perChainJoined.join(bothChainCells, { how: "left", on: ["sampleId"] })
+            // scCellsBothChains (cells with >=2 distinct chains) feeds only the paired scCellsTotal;
+            // in heavy-only mode scCellsTotal comes from cellsPerSample, so skip this aggregation/join.
+            if !scHeavyOnly {
+                bothChainCells := cellsPerSampleChainCounts.filter(pt.col("_numChains").gt(pairMinExclusive)).groupBy("sampleId").agg(pt.col("cellKey").count().alias("scCellsBothChains"))
+                perChainJoined = perChainJoined.join(bothChainCells, { how: "left", on: ["sampleId"] })
+            }
 
             // Filter to paired cells only
             scPaired := scAll.join(pairedKeys, { how: "inner", on: ["sampleId", "cellKey"] })

--- a/workflow/src/main.tpl.tengo
+++ b/workflow/src/main.tpl.tengo
@@ -137,7 +137,8 @@ wf.body(func(args) {
 				imputeGermline: args.imputeGermline,
 				exportMinQuality: args.exportMinQuality,
 				stopCodonTypes: args.stopCodonTypes,
-				stopCodonReplacements: args.stopCodonReplacements
+				stopCodonReplacements: args.stopCodonReplacements,
+				scHeavyOnly: args.scHeavyOnly
 		})
 	})
 

--- a/workflow/src/mixcr-analyze.tpl.tengo
+++ b/workflow/src/mixcr-analyze.tpl.tengo
@@ -80,11 +80,7 @@ self.body(func(inputs) {
 		arg("analyze").arg("--use-local-temp")
 
 	// CPUs number per process
-	if !is_undefined(perProcessCPUs) {
-	    mixcrCmdBuilder.cpu(perProcessCPUs)
-	} else {
-	    mixcrCmdBuilder.cpu(16)     // default CPUs number per sample
-	}
+	perProcessCPUsResolved := is_undefined(perProcessCPUs) ? 16 : perProcessCPUs
 
 	// Memory limit per process.
 	// Size analyze RAM from the input reads' file size, on top of a per-analysis
@@ -96,10 +92,10 @@ self.body(func(inputs) {
 	// single-cell+MiTool pipelines, which need that headroom regardless of size);
 	// the linear term scales with input volume; the 256 GiB cap bounds the largest.
 	// An "Advanced Settings" memory override takes precedence; on backends that
-	// cannot evaluate resource formulas, memFormula falls back to the baseline.
+	// cannot evaluate resource formulas, the formula's static fallback is the baseline.
     if !is_undefined(perProcessMemGB) {
         // memory per process was set in "Advanced Settings" block directly
-		mixcrCmdBuilder.mem(string(perProcessMemGB) + "GiB")
+		mixcrCmdBuilder.cpu(perProcessCPUsResolved).mem(string(perProcessMemGB) + "GiB")
 	} else {
 		baseMemGiB := 64
 		if hasMiToolSteps {
@@ -107,13 +103,13 @@ self.body(func(inputs) {
 		} else if hasAssembleContigs || hasAssembleCells {
 			baseMemGiB = 110
 		}
-		f := exec.formula
-		mixcrCmdBuilder.memFormula(
-			f.clamp(
-				f.add(f.gib(baseMemGiB), f.mul(f.size("reads"), 4)),
-				f.gib(baseMemGiB),
-				f.gib(256)),
-			{ fallback: string(baseMemGiB) + "GiB" })
+		// workflow-tengo 6.7 fluent formula API fed via .resources({ onCPU: { cpu, ram } }).
+		formula := exec.formula
+		memFormula := formula.gib(baseMemGiB).
+			plus(formula.size("reads").times(4)).
+			between(formula.gib(baseMemGiB), formula.gib(256)).
+			staticFallback(formula.gib(baseMemGiB))
+		mixcrCmdBuilder.resources({ onCPU: { cpu: perProcessCPUsResolved, ram: memFormula } })
 	}
 
 	if !is_undefined(limitInput) {

--- a/workflow/src/process-single-cell.tpl.tengo
+++ b/workflow/src/process-single-cell.tpl.tengo
@@ -2,6 +2,7 @@
 
 ll := import("@platforma-sdk/workflow-tengo:ll")
 self := import("@platforma-sdk/workflow-tengo:tpl.light")
+smart := import("@platforma-sdk/workflow-tengo:smart")
 pConstants := import("@platforma-sdk/workflow-tengo:pframes.constants")
 assets := import("@platforma-sdk/workflow-tengo:assets")
 exec := import("@platforma-sdk/workflow-tengo:exec")
@@ -29,6 +30,8 @@ self.body(func(inputs) {
 	ll.assert(inputDataMeta.keyLength == 1, "unexpected number of aggregation axes")
 
 	byCellTagB := inputs.byCellTagB
+	// Chain B (light chain) is absent in heavy-chain-only (VHH) single-cell mode.
+	hasChainB := !is_undefined(byCellTagB)
 	propertiesA := inputs.propertiesA
 	propertiesB := inputs.propertiesB
 
@@ -138,7 +141,7 @@ self.body(func(inputs) {
 	}
 
 	chainAOutput := preprocessByCell(byCellTagA)
-	chainBOutput := preprocessByCell(byCellTagB)
+	chainBOutput := hasChainB ? preprocessByCell(byCellTagB) : undefined
 
 	//
 	// Cell grouping - Reimplemented with PTabler pt API
@@ -146,17 +149,11 @@ self.body(func(inputs) {
 	cellGroupingWf := pt.workflow()
 
 	chainATableDf := cellGroupingWf.frame(chainAOutput, {xsvType: "tsv"})
-	chainBTableDf := cellGroupingWf.frame(chainBOutput, {xsvType: "tsv"})
 
-	// Dynamically generate filter steps for chains A and B, ranks 1 and 2
-	// Store resulting DataFrames in a map for easier access
+	// Filter steps for chain A (and chain B when present), ranks 1 and 2
 	rankedDfs := {}
-	for chainData in [{prefix: "a", df: chainATableDf}, {prefix: "b", df: chainBTableDf}] {
-		for rankVal in [1, 2] {
-			dfKey := "chain_" + chainData.prefix + "_rank" + string(rankVal) + "_df"
-			rankedDfs[dfKey] = chainData.df.filter(pt.col("chainRank").eq(rankVal))
-		}
-	}
+	rankedDfs["chain_a_rank1_df"] = chainATableDf.filter(pt.col("chainRank").eq(1))
+	rankedDfs["chain_a_rank2_df"] = chainATableDf.filter(pt.col("chainRank").eq(2))
 
 	chainAMergedDf := rankedDfs["chain_a_rank1_df"].join(rankedDfs["chain_a_rank2_df"], {
 		how: "full",
@@ -166,45 +163,60 @@ self.body(func(inputs) {
 		rightColumns: [{ column: "clonotypeKey", rename: "clonotypeKeyA2" }]
 	})
 
-	chainBMergedDf := rankedDfs["chain_b_rank1_df"].join(rankedDfs["chain_b_rank2_df"], {
-		how: "full",
-		on: ["sampleId", "cellKey"],
-		coalesce: true,
-		leftColumns: [{ column: "clonotypeKey", rename: "clonotypeKeyB1" }],
-		rightColumns: [{ column: "clonotypeKey", rename: "clonotypeKeyB2" }]
-	})
+	// scClonotypeKey composition and per-cell filter adapt to the number of chains:
+	//   paired     -> hash(A1,A2,B1,B2), keep cells with both primary chains
+	//   heavy-only -> hash(A1,A2),       keep cells with the (heavy) primary chain
+	scKeyParts := [
+		pt.col("clonotypeKeyA1").fillNull("NA"),
+		pt.col("clonotypeKeyA2").fillNull("NA")
+	]
+	filterCondition := pt.col("clonotypeKeyA1").isNotNull()
+	groupByCols := ["scClonotypeKey", "clonotypeKeyA1", "clonotypeKeyA2"]
 
-	allChainsMergedDf := chainAMergedDf.join(chainBMergedDf, {
-		how: "full",
-		on: ["sampleId", "cellKey"],
-		coalesce: true
-	})
+	allChainsMergedDf := chainAMergedDf
+	if hasChainB {
+		chainBTableDf := cellGroupingWf.frame(chainBOutput, {xsvType: "tsv"})
+		rankedDfs["chain_b_rank1_df"] = chainBTableDf.filter(pt.col("chainRank").eq(1))
+		rankedDfs["chain_b_rank2_df"] = chainBTableDf.filter(pt.col("chainRank").eq(2))
+
+		chainBMergedDf := rankedDfs["chain_b_rank1_df"].join(rankedDfs["chain_b_rank2_df"], {
+			how: "full",
+			on: ["sampleId", "cellKey"],
+			coalesce: true,
+			leftColumns: [{ column: "clonotypeKey", rename: "clonotypeKeyB1" }],
+			rightColumns: [{ column: "clonotypeKey", rename: "clonotypeKeyB2" }]
+		})
+
+		allChainsMergedDf = chainAMergedDf.join(chainBMergedDf, {
+			how: "full",
+			on: ["sampleId", "cellKey"],
+			coalesce: true
+		})
+
+		scKeyParts = append(scKeyParts,
+			pt.col("clonotypeKeyB1").fillNull("NA"),
+			pt.col("clonotypeKeyB2").fillNull("NA"))
+		filterCondition = pt.and(
+			pt.col("clonotypeKeyA1").isNotNull(),
+			pt.col("clonotypeKeyB1").isNotNull()
+		)
+		groupByCols = ["scClonotypeKey", "clonotypeKeyA1", "clonotypeKeyA2", "clonotypeKeyB1", "clonotypeKeyB2"]
+	}
 
 	scClonotypeKeyExpr := pt.concatStr(
-		[
-			pt.col("clonotypeKeyA1").fillNull("NA"),
-			pt.col("clonotypeKeyA2").fillNull("NA"),
-			pt.col("clonotypeKeyB1").fillNull("NA"),
-			pt.col("clonotypeKeyB2").fillNull("NA")
-		],
+		scKeyParts,
 		{delimiter: "#"}
 	).hash("sha256", "base64_alphanumeric", 120).alias("scClonotypeKey")
 
 	allChainsMergedWithScKeyDf := allChainsMergedDf.withColumns(scClonotypeKeyExpr)
 
-	filterCondition := pt.and(
-		pt.col("clonotypeKeyA1").isNotNull(),
-		pt.col("clonotypeKeyB1").isNotNull()
-	)
 	allChainsFilteredDf := allChainsMergedWithScKeyDf.filter(filterCondition)
 
 	allChainsFilteredDf.
 		withColumns(pt.lit(1).alias("1")).
 		save("cells.tsv", {columns: ["sampleId", "cellKey", "scClonotypeKey", "1"]})
 
-	clonotypeTableDf := allChainsFilteredDf.groupBy(
-		"scClonotypeKey", "clonotypeKeyA1", "clonotypeKeyA2", "clonotypeKeyB1", "clonotypeKeyB2"
-	).agg(
+	clonotypeTableDf := allChainsFilteredDf.groupBy(groupByCols...).agg(
 		pt.col("sampleId").nUnique().alias("sampleCount"),
 		pt.col("cellKey").count().alias("uniqueCellCountTotal")
 	)
@@ -236,17 +248,22 @@ self.body(func(inputs) {
 	//
 
 	propertiesAFile := propertiesA.inputs()["[]"]
-	propertiesBFile := propertiesB.inputs()["[]"]
 
 	outputProcessingWf := pt.workflow()
 
-	// Schema for clonotype.tsv (main_clonotypes table)
+	// Schema for clonotype.tsv (main_clonotypes table). Chain B columns only exist when paired.
 	clonotypeTableSchema := [
 		{ column: "scClonotypeKey", type: "String" },
 		{ column: "clonotypeKeyA1", type: "String" },
-		{ column: "clonotypeKeyA2", type: "String" },
-		{ column: "clonotypeKeyB1", type: "String" },
-		{ column: "clonotypeKeyB2", type: "String" },
+		{ column: "clonotypeKeyA2", type: "String" }
+	]
+	if hasChainB {
+		clonotypeTableSchema = clonotypeTableSchema + [
+			{ column: "clonotypeKeyB1", type: "String" },
+			{ column: "clonotypeKeyB2", type: "String" }
+		]
+	}
+	clonotypeTableSchema = clonotypeTableSchema + [
 		{ column: "sampleCount", type: "Int" },
 		{ column: "uniqueCellCountTotal", type: "Long" }
 	]
@@ -264,15 +281,6 @@ self.body(func(inputs) {
 		inferSchema: false
 	})
 
-	propsBSchema := [{ column: "clonotypeKey", type: "String" }]
-	propsBDf := outputProcessingWf.frame(propertiesBFile, {
-		xsvType: "tsv",
-		id: "props_b",
-		schema: propsBSchema,
-		inferSchema: false
-	})
-
-
 	clonotypeColumnNames := []
 	for cc in schemaPerClonotypeNoAggregates {
 		clonotypeColumnNames = append(clonotypeColumnNames, cc.column)
@@ -280,17 +288,30 @@ self.body(func(inputs) {
 
 	finalOutputColumns := ["scClonotypeKey", "clonotypeKey"] + clonotypeColumnNames
 
-
+	// Chain A positions always produced; chain B positions only for paired receptors.
 	chainMappings := [
 		{ chainKeyCol: "clonotypeKeyA1", propsTable: "props_a", internalOutTable: "props_a1_joined", finalOutFile: "properties_a_primary.tsv" },
-		{ chainKeyCol: "clonotypeKeyA2", propsTable: "props_a", internalOutTable: "props_a2_joined", finalOutFile: "properties_a_secondary.tsv" },
-		{ chainKeyCol: "clonotypeKeyB1", propsTable: "props_b", internalOutTable: "props_b1_joined", finalOutFile: "properties_b_primary.tsv" },
-		{ chainKeyCol: "clonotypeKeyB2", propsTable: "props_b", internalOutTable: "props_b2_joined", finalOutFile: "properties_b_secondary.tsv" }
+		{ chainKeyCol: "clonotypeKeyA2", propsTable: "props_a", internalOutTable: "props_a2_joined", finalOutFile: "properties_a_secondary.tsv" }
 	]
 
 	propsMapDfs := {
-		"props_a": propsADf,
-		"props_b": propsBDf
+		"props_a": propsADf
+	}
+
+	if hasChainB {
+		propertiesBFile := propertiesB.inputs()["[]"]
+		propsBSchema := [{ column: "clonotypeKey", type: "String" }]
+		propsBDf := outputProcessingWf.frame(propertiesBFile, {
+			xsvType: "tsv",
+			id: "props_b",
+			schema: propsBSchema,
+			inferSchema: false
+		})
+		propsMapDfs["props_b"] = propsBDf
+		chainMappings = chainMappings + [
+			{ chainKeyCol: "clonotypeKeyB1", propsTable: "props_b", internalOutTable: "props_b1_joined", finalOutFile: "properties_b_primary.tsv" },
+			{ chainKeyCol: "clonotypeKeyB2", propsTable: "props_b", internalOutTable: "props_b2_joined", finalOutFile: "properties_b_secondary.tsv" }
+		]
 	}
 
 	for mapping in chainMappings {
@@ -317,11 +338,21 @@ self.body(func(inputs) {
 
 	outputProcessingRunResult := outputProcessingWf.run()
 
-	propsAPrimaryFile := outputProcessingRunResult.getFile(chainMappings[0].finalOutFile)
-	propsBPrimaryFile := outputProcessingRunResult.getFile(chainMappings[2].finalOutFile)
+	propsAPrimaryFile := outputProcessingRunResult.getFile("properties_a_primary.tsv")
+	propsASecondaryFile := outputProcessingRunResult.getFile("properties_a_secondary.tsv")
+	// Chain B outputs must still be assigned (defineOutputs fields cannot be undefined);
+	// in heavy-chain-only mode they are null resources and are not collected by the caller.
+	propsBPrimaryFile := smart.createNullResource()
+	propsBSecondaryFile := smart.createNullResource()
+	if hasChainB {
+		propsBPrimaryFile = outputProcessingRunResult.getFile("properties_b_primary.tsv")
+		propsBSecondaryFile = outputProcessingRunResult.getFile("properties_b_secondary.tsv")
+	}
 
-	// Sum SHM mutation columns across primary A+B chains
-	shmTsv := undefined
+	// Sum SHM mutation columns across primary chains (A only when heavy-only, A+B when paired).
+	// Default to a null resource (not undefined): tpl assigns every declared output and panics
+	// on undefined. shmMapping is empty for non-VDJRegion assembling features.
+	shmTsv := smart.createNullResource()
 	if len(shmMapping) > 0 {
 		shmSchema := [{ column: "scClonotypeKey", type: "String" }]
 		for m in shmMapping {
@@ -335,13 +366,6 @@ self.body(func(inputs) {
 			schema: shmSchema,
 			inferSchema: false
 		})
-		propsBShmDf := shmWf.frame(propsBPrimaryFile, {
-			xsvType: "tsv",
-			schema: shmSchema,
-			inferSchema: false,
-			id: "props_b_shm"
-		})
-
 		// Cast "region_not_covered" to null, then to Int
 		castExprs := []
 		for m in shmMapping {
@@ -354,30 +378,48 @@ self.body(func(inputs) {
 			)
 		}
 		propsAShmDf = propsAShmDf.withColumns(castExprs...)
-		propsBShmDf = propsBShmDf.withColumns(castExprs...)
 
-		//Join A and B chains
-		leftCols := []
-		rightCols := []
-		for m in shmMapping {
-			leftCols = append(leftCols, { column: m.tsvColumn, rename: m.outputColumn + "_A" })
-			rightCols = append(rightCols, { column: m.tsvColumn, rename: m.outputColumn + "_B" })
-		}
+		shmCombinedDf := undefined
+		if hasChainB {
+			propsBShmDf := shmWf.frame(propsBPrimaryFile, {
+				xsvType: "tsv",
+				schema: shmSchema,
+				inferSchema: false,
+				id: "props_b_shm"
+			})
+			propsBShmDf = propsBShmDf.withColumns(castExprs...)
 
-		shmCombinedDf := propsAShmDf.join(propsBShmDf, {
-			how: "full",
-			on: ["scClonotypeKey"],
-			coalesce: true,
-			leftColumns: leftCols,
-			rightColumns: rightCols
-		})
+			//Join A and B chains
+			leftCols := []
+			rightCols := []
+			for m in shmMapping {
+				leftCols = append(leftCols, { column: m.tsvColumn, rename: m.outputColumn + "_A" })
+				rightCols = append(rightCols, { column: m.tsvColumn, rename: m.outputColumn + "_B" })
+			}
 
-		// Sum SHM mutation columns across primary A+B chains
-		for m in shmMapping {
-			shmCombinedDf = shmCombinedDf.withColumns(
-				pt.col(m.outputColumn + "_A").plus(pt.col(m.outputColumn + "_B")).
-					alias(m.outputColumn)
-			)
+			shmCombinedDf = propsAShmDf.join(propsBShmDf, {
+				how: "full",
+				on: ["scClonotypeKey"],
+				coalesce: true,
+				leftColumns: leftCols,
+				rightColumns: rightCols
+			})
+
+			// Sum SHM mutation columns across primary A+B chains
+			for m in shmMapping {
+				shmCombinedDf = shmCombinedDf.withColumns(
+					pt.col(m.outputColumn + "_A").plus(pt.col(m.outputColumn + "_B")).
+						alias(m.outputColumn)
+				)
+			}
+		} else {
+			// Heavy-only: mutation counts come from the single heavy chain directly
+			shmCombinedDf = propsAShmDf
+			for m in shmMapping {
+				shmCombinedDf = shmCombinedDf.withColumns(
+					pt.col(m.tsvColumn).alias(m.outputColumn)
+				)
+			}
 		}
 
 		// Calculate CDR mutation fraction
@@ -417,11 +459,13 @@ self.body(func(inputs) {
 		// used to build cell <-> clonotype linker column
 		cellsTsv: cellsTsv,
 
-		// must have scClonotypeKey columns
+		// must have scClonotypeKey columns.
+		// Chain B outputs are undefined in heavy-chain-only (VHH) mode and are not
+		// collected by the caller (they are absent from singleCellOutputs).
 		propertiesAPrimaryTsv: propsAPrimaryFile,
-		propertiesASecondaryTsv: outputProcessingRunResult.getFile(chainMappings[1].finalOutFile),
+		propertiesASecondaryTsv: propsASecondaryFile,
 		propertiesBPrimaryTsv: propsBPrimaryFile,
-		propertiesBSecondaryTsv: outputProcessingRunResult.getFile(chainMappings[3].finalOutFile),
+		propertiesBSecondaryTsv: propsBSecondaryFile,
 
 		shmTsv: shmTsv
 	}

--- a/workflow/src/process.tpl.tengo
+++ b/workflow/src/process.tpl.tengo
@@ -70,6 +70,7 @@ self.body(func(inputs) {
 	libraryId := params.libraryId
 	presetCommonName := params.presetCommonName
 	isLibraryFileGzipped := params.isLibraryFileGzipped
+	scHeavyOnly := params.scHeavyOnly
 
 	sampleIdAxisSpec := inputSpec.axesSpec[0]
 
@@ -301,10 +302,19 @@ self.body(func(inputs) {
 	chains := []
 	receptors := []
 
+	// Effective chains for a receptor. In heavy-chain-only (VHH) mode the IG receptor
+	// contributes only its heavy chain, so no light chain is exported or paired.
+	effectiveReceptorChains := func(receptor) {
+		if scHeavyOnly && isSingleCell && receptor == "IG" {
+			return ["IGHeavy"]
+		}
+		return receptorInfos[receptor].chains
+	}
+
 	for chainOrReceptor in receptorsOrChains {
 		if receptorInfos[chainOrReceptor] != undefined {
 			receptors += [chainOrReceptor]
-			chains += receptorInfos[chainOrReceptor].chains
+			chains += effectiveReceptorChains(chainOrReceptor)
 		} else {
 			if is_undefined(chainInfos[chainOrReceptor]) {
 				ll.panic("chainInfo not found for %v", chainOrReceptor)
@@ -641,6 +651,9 @@ self.body(func(inputs) {
 
 		for receptor in receptors {
 			receptorInfo := receptorInfos[receptor]
+			// In heavy-chain-only (VHH) mode a receptor may have a single chain (A only).
+			effectiveChains := effectiveReceptorChains(receptor)
+			hasChainB := len(effectiveChains) > 1
 
 			singleCellOutputs := [ {
 				type: "Resource",
@@ -691,10 +704,9 @@ self.body(func(inputs) {
 					columnsSpecPerClonotypeSecondary += [ col ]
 				}
 			}
-			for chainIdx in [0, 1] {
+			for chainIdx, chain in effectiveChains {
 				// "A" chain is always the one that is more diverse
 				chainLetterU := ["A", "B"][chainIdx]
-				chain := receptorInfo.chains[chainIdx]
 				chainNameU := chainInfos[chain].shortName
 				chainNameL := text.to_lower(chainNameU)
 
@@ -811,19 +823,35 @@ self.body(func(inputs) {
 				} ]
 			}
 
-			chainA := receptorInfo.chains[0]
-			chainB := receptorInfo.chains[1]
+			chainA := effectiveChains[0]
+			chainB := hasChainB ? effectiveChains[1] : undefined
 
 			// Using A chain files as main PColumn for xsv conversion through pframes.processColumn.
 			// Since we aggregate by sample, this is just a single pass through the data.
 
-			// manual data anonymization
-			anonymizationResult := anonymize.anonymizePKeys({
-				byCellTagAData: perChainResults[chainA].tsvForSingleCell.data,
-				byCellTagBData: perChainResults[chainB].tsvForSingleCell.data
-			}, [0])
+			// manual data anonymization (chain B only present for paired receptors)
+			anonymizeInput := {
+				byCellTagAData: perChainResults[chainA].tsvForSingleCell.data
+			}
+			if hasChainB {
+				anonymizeInput["byCellTagBData"] = perChainResults[chainB].tsvForSingleCell.data
+			}
+			anonymizationResult := anonymize.anonymizePKeys(anonymizeInput, [0])
 			byCellTagAData := anonymizationResult.result.byCellTagAData
-			byCellTagBData := anonymizationResult.result.byCellTagBData
+
+			scExtra := {
+				propertiesA: perChainResults[chainA].clonotypeProperties.data,
+				params: {
+					mainAbundanceColumn: mainAbundanceColumnUnnormalized,
+					mainIsProductiveColumn: mainIsProductiveColumn,
+					schemaPerClonotypeNoAggregates: columnsToSchema(columnsSpecPerClonotypeNoAggregates),
+					shmMapping: shmMapping
+				}
+			}
+			if hasChainB {
+				scExtra["byCellTagB"] = anonymizationResult.result.byCellTagBData
+				scExtra["propertiesB"] = perChainResults[chainB].clonotypeProperties.data
+			}
 
 			singleCellResult := pframes.processColumn(
 				{ spec: perChainResults[chainA].tsvForSingleCell.spec, data: byCellTagAData },
@@ -832,17 +860,7 @@ self.body(func(inputs) {
 				{
 					aggregate: ["pl7.app/sampleId"],
 					traceSteps: [{type: "milaboratories.mixcr-clonotyping.processSingleCell", id: blockId + "." + receptor, importance: 80, label: receptorInfo.name}],
-					extra: {
-						byCellTagB: byCellTagBData,
-						propertiesA: perChainResults[chainA].clonotypeProperties.data,
-						propertiesB: perChainResults[chainB].clonotypeProperties.data,
-						params: {
-							mainAbundanceColumn: mainAbundanceColumnUnnormalized,
-							mainIsProductiveColumn: mainIsProductiveColumn,
-							schemaPerClonotypeNoAggregates: columnsToSchema(columnsSpecPerClonotypeNoAggregates),
-							shmMapping: shmMapping
-						}
-					}
+					extra: scExtra
 				}
 			)
 
@@ -860,8 +878,10 @@ self.body(func(inputs) {
 
 			singleCellResult.addXsvOutputToBuilder(clonotypes, "propertiesAPrimary", "clonotypeProperties/" + receptor + "/aPrimary/")
 			singleCellResult.addXsvOutputToBuilder(clonotypes, "propertiesASecondary", "clonotypeProperties/" + receptor + "/aSecondary/")
-			singleCellResult.addXsvOutputToBuilder(clonotypes, "propertiesBPrimary", "clonotypeProperties/" + receptor + "/bPrimary/")
-			singleCellResult.addXsvOutputToBuilder(clonotypes, "propertiesBSecondary", "clonotypeProperties/" + receptor + "/bSecondary/")
+			if hasChainB {
+				singleCellResult.addXsvOutputToBuilder(clonotypes, "propertiesBPrimary", "clonotypeProperties/" + receptor + "/bPrimary/")
+				singleCellResult.addXsvOutputToBuilder(clonotypes, "propertiesBSecondary", "clonotypeProperties/" + receptor + "/bSecondary/")
+			}
 
 			if hasShm {
 				singleCellResult.addXsvOutputToBuilder(clonotypes, "shmCombined", "clonotypeProperties/" + receptor + "/shmCombined/")
@@ -890,7 +910,8 @@ self.body(func(inputs) {
 		productiveFeature: productiveFeature,
 		stopCodonTypes: params.stopCodonTypes,
 		stopCodonReplacements: params.stopCodonReplacements,
-		singleCellChainTsvsData: singleCellChainTsvs
+		singleCellChainTsvsData: singleCellChainTsvs,
+		scHeavyOnly: scHeavyOnly
 	})
 
 	return {

--- a/workflow/src/qc-report-columns.lib.tengo
+++ b/workflow/src/qc-report-columns.lib.tengo
@@ -6,7 +6,7 @@ pConstants := import("@platforma-sdk/workflow-tengo:pframes.constants")
 text := import("text")
 
 // QC Report column specifications function
-getQcReportColumns := func(hasUmi, isSingleCell, sampleIdAxisSpec, chains, cellTags, umiTags, hasAssembleCells) {
+getQcReportColumns := func(hasUmi, isSingleCell, sampleIdAxisSpec, chains, cellTags, umiTags, hasAssembleCells, scHeavyOnly) {
     if is_undefined(umiTags) {
         umiTags = []
     }
@@ -805,8 +805,11 @@ getQcReportColumns := func(hasUmi, isSingleCell, sampleIdAxisSpec, chains, cellT
     ]
 
     singleCellColumns := []
-    
-    // Paired cells total (single-cell): number of cells with distinct chains per sample
+
+    // Cells total (single-cell). Paired mode counts cells with distinct chains; heavy-only
+    // (VHH) mode counts all cells carrying the single chain.
+    scCellsTotalLabel := scHeavyOnly ? "Total number of cells" : "Total number of cells (with paired chains)"
+    scCellsTotalDescription := scHeavyOnly ? "Cells detected with a heavy (VHH) chain." : "Cells detected with at least two distinct chains (e.g. heavy and light)."
     singleCellColumns += [{
         column: "scCellsTotal",
         id: "sc-cells-total",
@@ -819,13 +822,14 @@ getQcReportColumns := func(hasUmi, isSingleCell, sampleIdAxisSpec, chains, cellT
                 "pl7.app/min": "0",
                 "pl7.app/table/orderPriority": "107900",
                 "pl7.app/table/visibility": "default",
-                "pl7.app/label": "Total number of cells (with paired chains)",
-                "pl7.app/description": "Cells detected with at least two distinct chains (e.g. heavy and light)."
+                "pl7.app/label": scCellsTotalLabel,
+                "pl7.app/description": scCellsTotalDescription
             }
         }
     }]
 
     // Per-chain clonotype counts (paired-only in single-cell), one column per available chain
+    clonotypesByChainDescription := scHeavyOnly ? "Number of unique clonotypes for this chain. Includes secondary chain rearrangements." : "Number of unique clonotypes for this chain (paired cells only). Includes secondary chain rearrangements."
     n := 107800
     for chain in chains {
         singleCellColumns += [{
@@ -841,31 +845,34 @@ getQcReportColumns := func(hasUmi, isSingleCell, sampleIdAxisSpec, chains, cellT
                     "pl7.app/table/orderPriority": string(n),
                     "pl7.app/table/visibility": "default",
                     "pl7.app/label": "Clonotypes by Chain " + chain,
-                    "pl7.app/description": "Number of unique clonotypes for this chain (paired cells only). Includes secondary chain rearrangements."
+                    "pl7.app/description": clonotypesByChainDescription
                 }
             }
         }]
         n -= 100
     }
 
-    // Clonotypes dropped because the cell was unpaired (single-chain only)
-    singleCellColumns += [{
-        column: "clonotypesDroppedUnpaired",
-        id: "clonotypes-dropped-unpaired",
-        allowNA: true,
-        naRegex: "NaN",
-        spec: {
-            name: "mixcr.com/reports/singleCell/clonotypesDroppedUnpaired",
-            valueType: "Long",
-            annotations: {
-                "pl7.app/min": "0",
-                "pl7.app/table/orderPriority": "108150",
-                "pl7.app/table/visibility": "optional",
-                "pl7.app/label": "Clonotypes Dropped - Unpaired",
-                "pl7.app/description": "Clonotypes discarded because their cell lacked a paired chain."
+    // Clonotypes dropped because the cell was unpaired. Only meaningful for paired
+    // receptors — omitted in heavy-chain-only (VHH) mode where pairing does not apply.
+    if !scHeavyOnly {
+        singleCellColumns += [{
+            column: "clonotypesDroppedUnpaired",
+            id: "clonotypes-dropped-unpaired",
+            allowNA: true,
+            naRegex: "NaN",
+            spec: {
+                name: "mixcr.com/reports/singleCell/clonotypesDroppedUnpaired",
+                valueType: "Long",
+                annotations: {
+                    "pl7.app/min": "0",
+                    "pl7.app/table/orderPriority": "108150",
+                    "pl7.app/table/visibility": "optional",
+                    "pl7.app/label": "Clonotypes Dropped - Unpaired",
+                    "pl7.app/description": "Clonotypes discarded because their cell lacked a paired chain."
+                }
             }
-        }
-    }]
+        }]
+    }
 
     // Single Cell columns
     singleCellColumns += [


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds support for single-cell VHH (nanobody / heavy-chain-only) data analysis in the MiXCR clonotyping block. When the new `scHeavyOnly` flag is enabled, the IG receptor is processed with only the heavy chain: light-chain pairing is skipped, the `clonotypesDroppedUnpaired` QC metric is omitted, cell-count semantics are adjusted, and SHM summation uses a single chain rather than A+B. The PR also modernises the build-script naming convention and bumps all Platforma SDK dependencies.

- **New `scHeavyOnly` flag**: threaded from model args → TypeScript model → main workflow → `process.tpl.tengo` → `export-report.tpl.tengo`, with a UI checkbox and model-layer validation ensuring only the IG receptor is selected.
- **`process-single-cell.tpl.tengo`**: replaces hard-coded two-chain logic with `hasChainB` guards derived from whether `byCellTagB` is present in inputs, covering cell grouping, schema generation, SHM computation, and output assignment.
- **Bug fix included**: `shmTsv := undefined` changed to `shmTsv := smart.createNullResource()`, preventing a framework panic when `shmMapping` is empty (non-VDJRegion presets).

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

The new VHH code path is cleanly gated by the optional scHeavyOnly flag, existing paired-mode behaviour is unchanged, and model-layer validation enforces the IG-only constraint.

All findings are style or efficiency observations with no functional impact. The shmTsv default change from undefined to smart.createNullResource() prevents a framework panic on presets without SHM data. The redundant bothChainCells aggregation in VHH mode wastes computation but produces correct output.

workflow/src/process-single-cell.tpl.tengo (hasChainB branching and SHM column handling), workflow/src/export-report.tpl.tengo (redundant bothChainCells aggregation in VHH mode)
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| workflow/src/process-single-cell.tpl.tengo | Core chain-B gating logic; replaces hard-coded two-chain loops with hasChainB guards. Also fixes the pre-existing shmTsv=undefined panic. Logic is sound; propertiesB is read unconditionally at top of body but safely gated before use. |
| workflow/src/process.tpl.tengo | Adds effectiveReceptorChains() to limit IG to IGHeavy in VHH mode; threads scHeavyOnly to export-report. for-loop refactored from index-based to enumerated correctly. |
| workflow/src/export-report.tpl.tengo | scHeavyOnly gates pairMinExclusive, clonotypesDroppedUnpaired column, and scCellsTotal source. Logic is correct; undefined-safe via == true comparison. |
| workflow/src/qc-report-columns.lib.tengo | New scHeavyOnly parameter adapts column labels and omits clonotypesDroppedUnpaired. Consistent with export-report logic. |
| model/src/args.ts | Adds optional scHeavyOnly boolean field to BlockArgsValidBase with a clear inline comment. |
| model/src/index.ts | Model-level validation enforces scHeavyOnly requires exactly the IG receptor. scHeavyOnly is forwarded to workflow args. |
| ui/src/SettingsPanel.vue | Adds VHH checkbox in Advanced Settings with a conflict warning when non-IG receptors are selected. Clears scHeavyOnly on leaving single-cell mode. |
| pnpm-workspace.yaml | Bumps all @platforma-sdk/* and @milaboratories/* catalog versions; no logic change. |
| package.json | Replaces generic build/build:dev scripts with PL_BUILD_CHANNEL/VARIANT/LOCATION-parameterised variants. Removes top-level build and build:dev — external tooling that relied on those names will need updating. |
| .github/workflows/build.yaml | Switches runner to hz-ubuntu-dind, separates build-script-name from build-before-publish-script-name, and adds HZ_CI cache credentials. |
| block/package.json | Adds shx rm -f package.tgz before packing to prevent stale artifact matching; defensive improvement. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant UI as SettingsPanel.vue
    participant Model as model/index.ts
    participant Main as main.tpl.tengo
    participant Process as process.tpl.tengo
    participant PSC as process-single-cell.tpl.tengo
    participant Export as export-report.tpl.tengo
    participant QCCols as qc-report-columns.lib.tengo

    UI->>Model: scHeavyOnly (boolean)
    Model->>Model: validate: only IG receptor allowed
    Model->>Main: args.scHeavyOnly
    Main->>Process: params.scHeavyOnly
    Process->>Process: effectiveReceptorChains(receptor)
    Process->>PSC: extra.byCellTagB omitted when VHH
    PSC->>PSC: "hasChainB = !is_undefined(byCellTagB)"
    PSC->>PSC: cell grouping and SHM branch on hasChainB
    PSC-->>Process: "propertiesBPrimaryTsv=nullResource in VHH"
    Process->>Export: singleCellChainTsvsData + scHeavyOnly
    Export->>Export: "pairMinExclusive = scHeavyOnly ? 0 : 1"
    Export->>QCCols: qcReportColumns(..., scHeavyOnly)
    QCCols-->>Export: adapted labels and omit unpaired-drop column
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant UI as SettingsPanel.vue
    participant Model as model/index.ts
    participant Main as main.tpl.tengo
    participant Process as process.tpl.tengo
    participant PSC as process-single-cell.tpl.tengo
    participant Export as export-report.tpl.tengo
    participant QCCols as qc-report-columns.lib.tengo

    UI->>Model: scHeavyOnly (boolean)
    Model->>Model: validate: only IG receptor allowed
    Model->>Main: args.scHeavyOnly
    Main->>Process: params.scHeavyOnly
    Process->>Process: effectiveReceptorChains(receptor)
    Process->>PSC: extra.byCellTagB omitted when VHH
    PSC->>PSC: "hasChainB = !is_undefined(byCellTagB)"
    PSC->>PSC: cell grouping and SHM branch on hasChainB
    PSC-->>Process: "propertiesBPrimaryTsv=nullResource in VHH"
    Process->>Export: singleCellChainTsvsData + scHeavyOnly
    Export->>Export: "pairMinExclusive = scHeavyOnly ? 0 : 1"
    Export->>QCCols: qcReportColumns(..., scHeavyOnly)
    QCCols-->>Export: adapted labels and omit unpaired-drop column
```

</a>
</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%204%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%204%0Aworkflow%2Fsrc%2Fprocess-single-cell.tpl.tengo%3A35-36%0A**%60propertiesB%60%20read%20unconditionally%20in%20VHH%20mode**%0A%0A%60inputs.propertiesB%60%20is%20read%20at%20the%20top%20of%20the%20body%20regardless%20of%20%60hasChainB%60.%20In%20VHH%20mode%20the%20caller%20never%20sets%20%60propertiesB%60%20in%20%60scExtra%60%2C%20so%20this%20evaluates%20to%20%60undefined%60.%20All%20downstream%20uses%20are%20correctly%20guarded%20by%20%60if%20hasChainB%20%7B%20...%20%7D%60%2C%20so%20there%20is%20no%20functional%20impact%2C%20but%20the%20pattern%20is%20inconsistent%20with%20how%20%60byCellTagB%60%20is%20handled%20%28explicit%20%60is_undefined%60%20check%20with%20a%20comment%29.%20A%20reader%20expecting%20parity%20between%20the%20two%20input%20guards%20may%20be%20confused.%0A%0A%23%23%23%20Issue%202%20of%204%0Aworkflow%2Fsrc%2Fprocess-single-cell.tpl.tengo%3A415-423%0A**%60shmCombinedDf%60%20column%20shadowing%20in%20heavy-only%20path**%0A%0AIn%20the%20heavy-only%20branch%2C%20%60withColumns%28pt.col%28m.tsvColumn%29.alias%28m.outputColumn%29%29%60%20appends%20%60m.outputColumn%60%20to%20the%20frame%20while%20%60m.tsvColumn%60%20remains%20present.%20If%20%60m.tsvColumn%20!%3D%20m.outputColumn%60%2C%20the%20resulting%20frame%20carries%20both%20the%20raw%20column%20and%20the%20aliased%20output%20column.%20The%20CDR-fraction%20block%20downstream%20presumably%20selects%20only%20the%20output%20column%2C%20so%20this%20is%20harmless%20in%20practice%2C%20but%20an%20explicit%20%60drop%60%20on%20the%20raw%20column%20would%20make%20the%20intent%20clearer%20and%20match%20the%20paired-mode%20frame%20shape.%0A%0A%60%60%60suggestion%0A%09%09%7D%20else%20%7B%0A%09%09%09%2F%2F%20Heavy-only%3A%20mutation%20counts%20come%20from%20the%20single%20heavy%20chain%20directly.%0A%09%09%09%2F%2F%20Rename%20tsvColumn%20to%20outputColumn%3B%20keep%20only%20the%20output%20name%20to%20match%20the%0A%09%09%09%2F%2F%20paired-mode%20frame%20shape%20%28where%20tsvColumn%20is%20not%20carried%20through%20the%20join%29.%0A%09%09%09shmCombinedDf%20%3D%20propsAShmDf%0A%09%09%09dropExprs%20%3A%3D%20%5B%5D%0A%09%09%09for%20m%20in%20shmMapping%20%7B%0A%09%09%09%09shmCombinedDf%20%3D%20shmCombinedDf.withColumns%28%0A%09%09%09%09%09pt.col%28m.tsvColumn%29.alias%28m.outputColumn%29%0A%09%09%09%09%29%0A%09%09%09%09if%20m.tsvColumn%20!%3D%20m.outputColumn%20%7B%0A%09%09%09%09%09dropExprs%20%3D%20append%28dropExprs%2C%20m.tsvColumn%29%0A%09%09%09%09%7D%0A%09%09%09%7D%0A%09%09%09if%20len%28dropExprs%29%20%3E%200%20%7B%0A%09%09%09%09shmCombinedDf%20%3D%20shmCombinedDf.drop%28dropExprs...%29%0A%09%09%09%7D%0A%09%09%7D%0A%60%60%60%0A%0A%23%23%23%20Issue%203%20of%204%0Aworkflow%2Fsrc%2Fprocess.tpl.tengo%3A302-309%0A**%60effectiveReceptorChains%60%20silently%20falls%20through%20for%20non-IG%20receptors%20when%20%60scHeavyOnly%60%20is%20set**%0A%0AWhen%20%60scHeavyOnly%60%20is%20%60true%60%20but%20%60receptor%20!%3D%20%22IG%22%60%20%28which%20the%20model%20blocks%20via%20validation%29%2C%20%60effectiveReceptorChains%60%20returns%20the%20full%20two-chain%20list.%20This%20is%20safe%20at%20runtime%20due%20to%20model%20validation%2C%20but%20a%20defensive%20%60ll.assert%60%20inside%20the%20function%20would%20make%20the%20invariant%20explicit%20and%20catch%20any%20future%20caller%20that%20bypasses%20model%20validation.%0A%0A%23%23%23%20Issue%204%20of%204%0Aworkflow%2Fsrc%2Fexport-report.tpl.tengo%3A397-409%0A**%60scCellsBothChains%60%20computed%20but%20unused%20in%20VHH%20mode**%0A%0AWhen%20%60scHeavyOnly%60%20is%20%60true%60%2C%20%60pairMinExclusive%20%3D%200%60%20causes%20%60bothChainCells%60%20%2F%20%60pairedKeys%60%20to%20include%20all%20cells%20%28equivalent%20to%20%60cellsPerSample%60%29%2C%20but%20the%20subsequent%20rename%20discards%20%60scCellsBothChains%60%20and%20uses%20%60scCellsTotal%60%20directly.%20The%20%60bothChainCells%60%20aggregation%20and%20join%20are%20redundant%20work%20in%20VHH%20mode.%20Consider%20skipping%20them%20with%20an%20%60if%20!scHeavyOnly%20%7B%20...%20%7D%60%20guard%20to%20avoid%20unnecessary%20computation%20on%20large%20datasets.%0A%0A&repo=platforma-open%2Fmixcr-clonotyping&pr=201&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 4 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 4
workflow/src/process-single-cell.tpl.tengo:35-36
**`propertiesB` read unconditionally in VHH mode**

`inputs.propertiesB` is read at the top of the body regardless of `hasChainB`. In VHH mode the caller never sets `propertiesB` in `scExtra`, so this evaluates to `undefined`. All downstream uses are correctly guarded by `if hasChainB { ... }`, so there is no functional impact, but the pattern is inconsistent with how `byCellTagB` is handled (explicit `is_undefined` check with a comment). A reader expecting parity between the two input guards may be confused.

### Issue 2 of 4
workflow/src/process-single-cell.tpl.tengo:415-423
**`shmCombinedDf` column shadowing in heavy-only path**

In the heavy-only branch, `withColumns(pt.col(m.tsvColumn).alias(m.outputColumn))` appends `m.outputColumn` to the frame while `m.tsvColumn` remains present. If `m.tsvColumn != m.outputColumn`, the resulting frame carries both the raw column and the aliased output column. The CDR-fraction block downstream presumably selects only the output column, so this is harmless in practice, but an explicit `drop` on the raw column would make the intent clearer and match the paired-mode frame shape.

```suggestion
		} else {
			// Heavy-only: mutation counts come from the single heavy chain directly.
			// Rename tsvColumn to outputColumn; keep only the output name to match the
			// paired-mode frame shape (where tsvColumn is not carried through the join).
			shmCombinedDf = propsAShmDf
			dropExprs := []
			for m in shmMapping {
				shmCombinedDf = shmCombinedDf.withColumns(
					pt.col(m.tsvColumn).alias(m.outputColumn)
				)
				if m.tsvColumn != m.outputColumn {
					dropExprs = append(dropExprs, m.tsvColumn)
				}
			}
			if len(dropExprs) > 0 {
				shmCombinedDf = shmCombinedDf.drop(dropExprs...)
			}
		}
```

### Issue 3 of 4
workflow/src/process.tpl.tengo:302-309
**`effectiveReceptorChains` silently falls through for non-IG receptors when `scHeavyOnly` is set**

When `scHeavyOnly` is `true` but `receptor != "IG"` (which the model blocks via validation), `effectiveReceptorChains` returns the full two-chain list. This is safe at runtime due to model validation, but a defensive `ll.assert` inside the function would make the invariant explicit and catch any future caller that bypasses model validation.

### Issue 4 of 4
workflow/src/export-report.tpl.tengo:397-409
**`scCellsBothChains` computed but unused in VHH mode**

When `scHeavyOnly` is `true`, `pairMinExclusive = 0` causes `bothChainCells` / `pairedKeys` to include all cells (equivalent to `cellsPerSample`), but the subsequent rename discards `scCellsBothChains` and uses `scCellsTotal` directly. The `bothChainCells` aggregation and join are redundant work in VHH mode. Consider skipping them with an `if !scHeavyOnly { ... }` guard to avoid unnecessary computation on large datasets.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["Changeset"](https://github.com/platforma-open/mixcr-clonotyping/commit/6e4669260dc49bf7db8e4efe3fc52e2a42dbda74) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43853985)</sub>

> Greptile also left **4 inline comments** on this PR.

**Context used:**

- Context used - Terms is a types in codebase. Provide the list of ... ([source](https://app.greptile.com/review/custom-context?memory=instruction-0))

<!-- /greptile_comment -->