### PR TITLE
MILAB-6621: fixed label fields made optional

### DIFF
--- a/.changeset/dark-numbers-occur.md
+++ b/.changeset/dark-numbers-occur.md
@@ -1,0 +1,6 @@
+---
+"@platforma-open/milaboratories.mixcr-clonotyping-2.model": patch
+"@platforma-open/milaboratories.mixcr-clonotyping-2": patch
+---
+
+fix: label fields made optional

--- a/model/src/args.ts
+++ b/model/src/args.ts
@@ -29,8 +29,8 @@ export const StopCodonReplacements = z
   .optional();
 
 const BlockArgsValidBase = z.object({
-  defaultBlockLabel: z.string(),
-  customBlockLabel: z.string(),
+  defaultBlockLabel: z.string().optional(),
+  customBlockLabel: z.string().optional(),
   input: PlRef,
   inputLibrary: PlRef.optional(),
   libraryFile: z


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR makes `defaultBlockLabel` and `customBlockLabel` optional in `BlockArgsValidBase`, so that both the "valid" and "partial" arg schemas no longer require these label fields.

- **`BlockArgsValidBase`** (`z.object`): the shared Zod schema base. `defaultBlockLabel` and `customBlockLabel` changed from `z.string()` (required) to `z.string().optional()`.
- **`BlockArgsValid`** (aliased from `BlockArgsValidBase`): fully-validated args type. Implicitly inherits the optionality change — these two fields are now allowed to be absent in fully-validated state.
- **`BlockArgs`** (`.partial()` of `BlockArgsValidBase`): partially-filled args type used during block configuration. The explicit `.partial({ defaultBlockLabel: true, customBlockLabel: true })` entries are now redundant since both fields are already optional in the base.

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge; the only concern is redundant `.partial()` entries left in `BlockArgs` now that both label fields are already optional in the base schema.

The change is minimal and intentional: making two label fields optional fixes the reported issue. Both `BlockArgsValid` and `BlockArgs` correctly reflect the new optionality. The only loose end is that the `.partial()` call in `BlockArgs` still lists `defaultBlockLabel` and `customBlockLabel`, which are now no-ops — a cleanup opportunity but not a defect.

model/src/args.ts — the `.partial()` call has two now-redundant entries worth cleaning up.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| model/src/args.ts | Makes `defaultBlockLabel` and `customBlockLabel` optional in `BlockArgsValidBase`, which propagates the optionality to both `BlockArgsValid` and `BlockArgs`; the existing `.partial()` entries for those two fields in `BlockArgs` become redundant dead code. |

</details>

<details><summary><h3>Class Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
classDiagram
    class BlockArgsValidBase {
        defaultBlockLabel: string? ~~string~~
        customBlockLabel: string? ~~string~~
        input: PlRef
        inputLibrary: PlRef?
        preset: Preset
        species: string?
        ...other fields...
    }

    class BlockArgsValid {
        <<alias of BlockArgsValidBase>>
        defaultBlockLabel: string?
        customBlockLabel: string?
    }

    class BlockArgs {
        <<partial of BlockArgsValidBase>>
        defaultBlockLabel: string?
        customBlockLabel: string?
        input: PlRef?
        preset: Preset?
    }

    BlockArgsValidBase <|-- BlockArgsValid : alias
    BlockArgsValidBase <|-- BlockArgs : .partial(input, preset)
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
classDiagram
    class BlockArgsValidBase {
        defaultBlockLabel: string? ~~string~~
        customBlockLabel: string? ~~string~~
        input: PlRef
        inputLibrary: PlRef?
        preset: Preset
        species: string?
        ...other fields...
    }

    class BlockArgsValid {
        <<alias of BlockArgsValidBase>>
        defaultBlockLabel: string?
        customBlockLabel: string?
    }

    class BlockArgs {
        <<partial of BlockArgsValidBase>>
        defaultBlockLabel: string?
        customBlockLabel: string?
        input: PlRef?
        preset: Preset?
    }

    BlockArgsValidBase <|-- BlockArgsValid : alias
    BlockArgsValidBase <|-- BlockArgs : .partial(input, preset)
```

</a>
</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Amodel%2Fsrc%2Fargs.ts%3A66-71%0ASince%20%60defaultBlockLabel%60%20and%20%60customBlockLabel%60%20are%20now%20already%20marked%20%60.optional%28%29%60%20in%20%60BlockArgsValidBase%60%2C%20the%20corresponding%20entries%20in%20the%20%60.partial%28%29%60%20call%20for%20%60BlockArgs%60%20are%20redundant.%20Removing%20them%20keeps%20the%20intent%20clear%20and%20avoids%20confusion%20for%20future%20readers.%0A%0A%60%60%60suggestion%0Aexport%20const%20BlockArgs%20%3D%20BlockArgsValidBase.partial%28%7B%0A%20%20input%3A%20true%2C%0A%20%20preset%3A%20true%2C%0A%7D%29%3B%0A%60%60%60%0A%0A&repo=platforma-open%2Fmixcr-clonotyping&pr=202&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
model/src/args.ts:66-71
Since `defaultBlockLabel` and `customBlockLabel` are now already marked `.optional()` in `BlockArgsValidBase`, the corresponding entries in the `.partial()` call for `BlockArgs` are redundant. Removing them keeps the intent clear and avoids confusion for future readers.

```suggestion
export const BlockArgs = BlockArgsValidBase.partial({
  input: true,
  preset: true,
});
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["MILAB-6621: fixed label fields made opti..."](https://github.com/platforma-open/mixcr-clonotyping/commit/be13dc35afd788bca0c098ffba88d1daf900da68) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44191336)</sub>

<!-- /greptile_comment -->