### PR TITLE
fix: size single-cell PTabler steps via workflow-tengo 6.8 formulas

### DIFF
--- a/.changeset/pt-memory-formula.md
+++ b/.changeset/pt-memory-formula.md
@@ -1,0 +1,11 @@
+---
+"@platforma-open/milaboratories.mixcr-clonotyping-2.workflow": patch
+"@platforma-open/milaboratories.mixcr-clonotyping-2": patch
+---
+
+fix: size single-cell PTabler steps by input volume
+
+Bump @platforma-sdk/workflow-tengo to 6.8.2. The single-cell pipeline's
+unsized `pt.workflow()` steps (cell grouping, output processing, SHM) now
+request CPU/RAM from the built-in input-size formula instead of the backend
+default, fixing out-of-memory failures on large datasets.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -40,8 +40,8 @@ catalogs:
       specifier: 1.80.4
       version: 1.80.4
     '@platforma-sdk/workflow-tengo':
-      specifier: 6.7.2
-      version: 6.7.2
+      specifier: 6.8.2
+      version: 6.8.2
     '@types/wicg-file-system-access':
       specifier: ^2023.10.7
       version: 2023.10.7
@@ -278,7 +278,7 @@ importers:
         version: 4.7.0-347-develop
       '@platforma-sdk/workflow-tengo':
         specifier: 'catalog:'
-        version: 6.7.2
+        version: 6.8.2
     devDependencies:
       '@platforma-sdk/tengo-builder':
         specifier: 'catalog:'
@@ -1158,6 +1158,9 @@ packages:
   '@milaboratories/pframes-rs-wasip2@1.1.55':
     resolution: {integrity: sha512-mwKTmcDiuN6Id2h+oxKX2W5igFhMxDvRZs4clsxhPTYZASSROrvsSsaoXS81meqfC0phx+BUaRpdrkVQIKSdxQ==}
 
+  '@milaboratories/pframes-rs-wasip2@1.1.56':
+    resolution: {integrity: sha512-54bhC6XCAVO09J/sqVwEKA4hhTa27BDDNdH8BE+6+LvjBVkg/qq2/f0MzdrVijrmagbr97F1zgj5wIgUqwCSoA==}
+
   '@milaboratories/pframes-rs-wasm@1.1.55':
     resolution: {integrity: sha512-kVOL+eAasfeiui5lQ5G92nsSiTNSsOnl1m+4my0tmbR7VTCa15dn1kd5RcXS3/8YO5oEcnGlCUhnu5kKMtweEw==}
     peerDependencies:
@@ -1603,8 +1606,14 @@ packages:
   '@platforma-open/milaboratories.software-ptabler@2.1.6':
     resolution: {integrity: sha512-LdDU9/z+iejw5F98J8DYVQKsjUGGiyu8rHWCjWCEqOVEP+N9QBcN4ibDgG4Xp/GL+IzKxicAkf2Ae9lHollD6w==}
 
+  '@platforma-open/milaboratories.software-ptabler@2.1.8':
+    resolution: {integrity: sha512-28dKwcKNIB/8OYH6l/li7Qa/aE2NgDVtNUmN8v6jZsLKT59ogFclz8ZrQ+OiQFzHQCLBlWBt5TdIHfHPxBaNFw==}
+
   '@platforma-open/milaboratories.software-ptexter@1.2.3':
     resolution: {integrity: sha512-5wwzvPko/tjkm6EnirsnjB+MO5mF//tgJplI+jPh3bcSHpEdHF+B9xg+S1owAnekqbimMrFZWqHSVY9ZmIHOjw==}
+
+  '@platforma-open/milaboratories.software-ptexter@1.2.4':
+    resolution: {integrity: sha512-4ZqhqksSNVKWhEB9WwrL0rU89G+00ulzH1urYyNA4EdBVGA4mwbKbw0K/zcwce/oUYYMdRl+epXmr0w9wHyNzA==}
 
   '@platforma-open/milaboratories.software-small-binaries.hello-world-py@1.0.10':
     resolution: {integrity: sha512-16BGRLIrsVW+YIaXwWLX6Nbm80PS5mQJEclHhjNbRrRTLHPaKI4RygZfBC0lLNzvHBiTXU4Qkh1+WmdovkshDg==}
@@ -1651,6 +1660,9 @@ packages:
 
   '@platforma-sdk/workflow-tengo@6.7.2':
     resolution: {integrity: sha512-KJ4tBigEDN+EIDy7K2u7PqxBIDrhwvnazJthApGg2N/HPZkinKmq0iMzHC9KZ0IsJVg6uxECIB2d2Acko33tOw==}
+
+  '@platforma-sdk/workflow-tengo@6.8.2':
+    resolution: {integrity: sha512-AHR/Y+vbyfda17A7xY2uH9TlXiBpM8242tTO6+lj8phA4/KS6mez4GLu4ZEaASlZpX6YkQsUs5LUxYQU7pXeiQ==}
 
   '@protobuf-ts/grpc-transport@2.11.1':
     resolution: {integrity: sha512-l6wrcFffY+tuNnuyrNCkRM8hDIsAZVLA8Mn7PKdVyYxITosYh60qW663p9kL6TWXYuDCL3oxH8ih3vLKTDyhtg==}
@@ -6319,6 +6331,8 @@ snapshots:
 
   '@milaboratories/pframes-rs-wasip2@1.1.55': {}
 
+  '@milaboratories/pframes-rs-wasip2@1.1.56': {}
+
   '@milaboratories/pframes-rs-wasm@1.1.55(@bytecodealliance/preview2-shim@0.17.9)(@milaboratories/pl-model-common@1.47.1)(@milaboratories/pl-model-middle-layer@1.30.13)':
     dependencies:
       '@bytecodealliance/preview2-shim': 0.17.9
@@ -6956,7 +6970,11 @@ snapshots:
 
   '@platforma-open/milaboratories.software-ptabler@2.1.6': {}
 
+  '@platforma-open/milaboratories.software-ptabler@2.1.8': {}
+
   '@platforma-open/milaboratories.software-ptexter@1.2.3': {}
+
+  '@platforma-open/milaboratories.software-ptexter@1.2.4': {}
 
   '@platforma-open/milaboratories.software-small-binaries.hello-world-py@1.0.10': {}
 
@@ -7052,8 +7070,8 @@ snapshots:
       '@milaboratories/pl-middle-layer': 1.66.4(@bytecodealliance/preview2-shim@0.17.9)(@types/node@24.10.2)
       '@milaboratories/pl-tree': 1.13.1
       '@platforma-sdk/model': 1.80.2
-      '@vitest/coverage-istanbul': 4.1.3(vitest@4.1.3)
-      vitest: 4.1.3(@types/node@24.10.2)(@vitest/coverage-istanbul@4.1.3(vitest@4.0.18(@types/node@24.10.2)(lightningcss@1.32.0)(yaml@2.8.2)))(vite@8.0.7(@types/node@24.10.2)(yaml@2.8.2))
+      '@vitest/coverage-istanbul': 4.1.3(vitest@4.0.18(@types/node@24.10.2)(lightningcss@1.32.0)(yaml@2.8.2))
+      vitest: 4.1.3(@types/node@24.10.2)(@vitest/coverage-istanbul@4.1.3)(vite@8.0.7(@types/node@24.10.2)(yaml@2.8.2))
     transitivePeerDependencies:
       - '@bytecodealliance/preview2-shim'
       - '@edge-runtime/vm'
@@ -7118,6 +7136,14 @@ snapshots:
       '@milaboratories/software-pframes-conv': 2.2.9
       '@platforma-open/milaboratories.software-ptabler': 2.1.6
       '@platforma-open/milaboratories.software-ptexter': 1.2.3
+      '@platforma-open/milaboratories.software-small-binaries': 2.1.1
+
+  '@platforma-sdk/workflow-tengo@6.8.2':
+    dependencies:
+      '@milaboratories/pframes-rs-wasip2': 1.1.56
+      '@milaboratories/software-pframes-conv': 2.2.9
+      '@platforma-open/milaboratories.software-ptabler': 2.1.8
+      '@platforma-open/milaboratories.software-ptexter': 1.2.4
       '@platforma-open/milaboratories.software-small-binaries': 2.1.1
 
   '@protobuf-ts/grpc-transport@2.11.1(@grpc/grpc-js@1.13.4)':
@@ -7839,7 +7865,7 @@ snapshots:
       vite: 8.0.7(@types/node@24.10.2)(yaml@2.8.2)
       vue: 3.5.25(typescript@5.9.3)
 
-  '@vitest/coverage-istanbul@4.1.3(vitest@4.1.3)':
+  '@vitest/coverage-istanbul@4.1.3(vitest@4.0.18(@types/node@24.10.2)(lightningcss@1.32.0)(yaml@2.8.2))':
     dependencies:
       '@babel/core': 7.29.0
       '@istanbuljs/schema': 0.1.3
@@ -7851,7 +7877,7 @@ snapshots:
       magicast: 0.5.2
       obug: 2.1.3
       tinyrainbow: 3.1.0
-      vitest: 4.1.3(@types/node@24.10.2)(@vitest/coverage-istanbul@4.1.3(vitest@4.0.18(@types/node@24.10.2)(lightningcss@1.32.0)(yaml@2.8.2)))(vite@8.0.7(@types/node@24.10.2)(yaml@2.8.2))
+      vitest: 4.0.18(@types/node@24.10.2)(lightningcss@1.32.0)(yaml@2.8.2)
     transitivePeerDependencies:
       - supports-color
 
@@ -10333,7 +10359,7 @@ snapshots:
       - tsx
       - yaml
 
-  vitest@4.1.3(@types/node@24.10.2)(@vitest/coverage-istanbul@4.1.3(vitest@4.0.18(@types/node@24.10.2)(lightningcss@1.32.0)(yaml@2.8.2)))(vite@8.0.7(@types/node@24.10.2)(yaml@2.8.2)):
+  vitest@4.1.3(@types/node@24.10.2)(@vitest/coverage-istanbul@4.1.3)(vite@8.0.7(@types/node@24.10.2)(yaml@2.8.2)):
     dependencies:
       '@vitest/expect': 4.1.3
       '@vitest/mocker': 4.1.3(vite@8.0.7(@types/node@24.10.2)(yaml@2.8.2))
@@ -10357,7 +10383,7 @@ snapshots:
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 24.10.2
-      '@vitest/coverage-istanbul': 4.1.3(vitest@4.1.3)
+      '@vitest/coverage-istanbul': 4.1.3(vitest@4.0.18(@types/node@24.10.2)(lightningcss@1.32.0)(yaml@2.8.2))
     transitivePeerDependencies:
       - msw
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -8,7 +8,7 @@ packages:
 catalog:
   '@milaboratories/ts-builder': 1.6.0
   '@milaboratories/ts-configs': 1.3.0
-  '@platforma-sdk/workflow-tengo': 6.7.2
+  '@platforma-sdk/workflow-tengo': 6.8.2
   '@platforma-sdk/model': 1.80.2
   '@platforma-sdk/ui-vue': 1.80.4
   '@platforma-sdk/tengo-builder': 4.0.18


### PR DESCRIPTION
## What

Bump `@platforma-sdk/workflow-tengo` `6.7.2 → 6.8.2` in the block catalog.

## Why

The single-cell pipeline has three `pt.workflow()` (PTabler) steps in `workflow/src/process-single-cell.tpl.tengo` that set **no** `.mem()`/`.cpu()`:

- `cellGroupingWf` (line 149)
- `outputProcessingWf` (line 252) — the step observed OOM-killing in the field
- `shmWf` (line 362)

On 6.7.2 these ran with the backend's medium-queue default, which does not scale with input size → OOM on large datasets.

workflow-tengo **6.8.0** added a built-in size-based default for `pt` runs that don't set explicit resources:

- `ram = between(2 GiB + 4 × size, 2 GiB, 64 GiB)` (static fallback 4 GiB)
- `cpu = between(2 + size / 16 GiB, 2, 8)` (static fallback 2)

So the bump alone makes these three steps request RAM/CPU scaled to the input blob size. No workflow source changes needed. The already-sized `pt` runs (`aggregate-by-clonotype-key`, `export-report`, `mixcr-export`, and the per-sample step in `process-single-cell`) keep their explicit values — an explicit `.mem()`/`.cpu()` still wins.

## Changes

- `pnpm-workspace.yaml` — catalog bump to 6.8.2
- `pnpm-lock.yaml` — re-resolved (bundled `software-ptabler` 2.1.6→2.1.8, `software-ptexter` 1.2.3→1.2.4)
- `.changeset/pt-memory-formula.md` — patch

No breaking changes between 6.7.2 and 6.8.2 (6.8.0 additive, 6.8.1/6.8.2 patches). Workflow builds clean with `pl-tengo build`.

## Caveat

On backends that cannot evaluate resource formulas (no `getBlobSize`), these steps fall back to **4 GiB**. On formula-capable backends they scale up to 64 GiB by input size.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR upgrades workflow-tengo so unsized single-cell PTabler steps use size-based resource formulas.
- **workflow-tengo** — the Tengo workflow SDK; upgraded from 6.7.2 to 6.8.2 to provide formula-based defaults for unsized PTabler runs.
- **PTabler (`pt.workflow`)** — the tabular-processing workflow primitive; its unsized cell-grouping, output-processing, and SHM steps now inherit input-size-based CPU and RAM requests.
- **Resource formula** — a runtime expression deriving resource requests from input blob size; introduced as the default behavior used by those unsized steps, with a static fallback on unsupported backends.
- **software-ptabler / software-ptexter** — bundled processing tools; transitively updated to 2.1.8 and 1.2.4.
- **Changeset** — release metadata describing package impact; adds patch releases for the workflow and block packages.
- The lockfile also contains unrelated Vitest coverage peer-resolution drift that should be cleaned up.

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

The workflow dependency upgrade appears safe to merge, but the unrelated Vitest coverage peer-resolution drift should be cleaned up to keep installs and coverage execution deterministic.

The intended workflow-tengo and bundled-tool updates are consistently represented, while the regenerated lockfile binds the 4.1.3 coverage plugin to Vitest 4.0.18 instead of its required 4.1.3 peer.

**Files Needing Attention:** pnpm-lock.yaml
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| pnpm-workspace.yaml | Updates the workflow-tengo catalog pin from 6.7.2 to 6.8.2. |
| pnpm-lock.yaml | Resolves workflow-tengo and bundled processing-tool updates, but also changes the Vitest coverage plugin to an incompatible peer binding. |
| .changeset/pt-memory-formula.md | Adds accurate patch-release notes for formula-based sizing of unsized single-cell PTabler steps. |

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  A[Single-cell input blobs] --> B[Unsized pt.workflow steps]
  B --> C[workflow-tengo 6.8.2 resource formula]
  C --> D[Size-based RAM request]
  C --> E[Size-based CPU request]
  D --> F[PTabler execution]
  E --> F
  C -. unsupported formula backend .-> G[Static fallback resources]
  G --> F
```
</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=%23%23%23%20Issue%201%0Apnpm-lock.yaml%3A7877-7879%0A**Mismatched%20Vitest%20peer%20resolution**%0A%0AThe%20regenerated%20lockfile%20binds%20%60%40vitest%2Fcoverage-istanbul%60%204.1.3%20to%20Vitest%204.0.18%20despite%20its%20exact%204.1.3%20peer%20requirement%2C%20while%20the%20workspace%20runner%20remains%20on%204.1.3.%20This%20unrelated%20resolution%20drift%20makes%20installs%20report%20an%20invalid%20peer%20graph%20and%20makes%20coverage%20behavior%20dependent%20on%20two%20different%20Vitest%20instances.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=platforma-open%2Fmixcr-clonotyping&pr=204&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
pnpm-lock.yaml:7877-7879
**Mismatched Vitest peer resolution**

The regenerated lockfile binds `@vitest/coverage-istanbul` 4.1.3 to Vitest 4.0.18 despite its exact 4.1.3 peer requirement, while the workspace runner remains on 4.1.3. This unrelated resolution drift makes installs report an invalid peer graph and makes coverage behavior dependent on two different Vitest instances.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: size single-cell PTabler steps via ..."](https://github.com/platforma-open/mixcr-clonotyping/commit/72890880d9fd8a55fa2eed1b445234e0845e7df4) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=48032065)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->