### PR TITLE
MILAB-6725: size exportClones from the .clns instead of a flat 12 GiB

### DIFF
--- a/.changeset/export-clones-memory.md
+++ b/.changeset/export-clones-memory.md
@@ -1,0 +1,29 @@
+---
+"@platforma-open/milaboratories.mixcr-clonotyping-2.workflow": patch
+"@platforma-open/milaboratories.mixcr-clonotyping-2": patch
+---
+
+fix: size the exportClones execs from the .clns instead of a flat 12 GiB
+
+`exportClones` was requesting a constant 12 GiB (or `perProcessMemGB / 4`),
+which has no relationship to what the command actually holds in memory. It
+reads the entire CloneSet into heap, and for single-cell exports it then
+materialises a second, expanded list — one clone per (clonotype × cell), each
+with its own split TagCount — which it sorts and re-ranks before writing. The
+`--chains` filter is applied only after that division, so exporting one chain
+group still pays the whole-file cost.
+
+With the `memory-from-limits` entrypoint a 12 GiB grant yields only 8788 MiB of
+heap (flat 3500 MiB non-heap reserve), and that was not enough for a 10.7k-cell
+/ 26.7k-clone 10x BCR sample — `exportClones` failed with `OutOfMemoryError`,
+taking the `clonotypes`, `clonotypeTables` and `qcReportTable` outputs with it.
+
+- RAM is now `clamp(perByte × size(clns), floor, 128 GiB)` — floor/slope 16 GiB
+  and 16 for the bulk export, 32 GiB and 32 for the single-cell export, which
+  pays the per-cell division multiplier.
+- An Advanced Settings memory override is now used as-is rather than being
+  quartered, matching how the analyze step treats the same setting. Projects
+  that set it will request 4× more for the export step than before.
+- The two PTabler steps are no longer sized off the mixcr step's budget; they
+  are left unsized so workflow-tengo 6.8's built-in input-volume formula
+  applies, as it already does for the rest of the single-cell pipeline.

--- a/.changeset/export-clones-memory.md
+++ b/.changeset/export-clones-memory.md
@@ -5,25 +5,24 @@
 
 fix: size the exportClones execs from the .clns instead of a flat 12 GiB
 
-`exportClones` was requesting a constant 12 GiB (or `perProcessMemGB / 4`),
-which has no relationship to what the command actually holds in memory. It
-reads the entire CloneSet into heap, and for single-cell exports it then
-materialises a second, expanded list — one clone per (clonotype × cell), each
-with its own split TagCount — which it sorts and re-ranks before writing. The
-`--chains` filter is applied only after that division, so exporting one chain
-group still pays the whole-file cost.
+`exportClones` requested a constant 12 GiB (or `perProcessMemGB / 4`) — a number
+unrelated to what the command holds in memory. It reads the entire CloneSet into
+heap, and single-cell exports then materialise a second, expanded list — one clone
+per (clonotype × cell), each with its own split TagCount — then sort and re-rank it.
+`--chains` filters only after that division, so exporting one chain group still pays
+the whole-file cost.
 
-With the `memory-from-limits` entrypoint a 12 GiB grant yields only 8788 MiB of
-heap (flat 3500 MiB non-heap reserve), and that was not enough for a 10.7k-cell
-/ 26.7k-clone 10x BCR sample — `exportClones` failed with `OutOfMemoryError`,
-taking the `clonotypes`, `clonotypeTables` and `qcReportTable` outputs with it.
+Under the `memory-from-limits` entrypoint a 12 GiB grant yields 8788 MiB of heap,
+because the non-heap reserve is a flat 3500 MiB. A 10.7k-cell / 26.7k-clone 10x BCR
+sample exhausted it: `exportClones` died with `OutOfMemoryError`, taking the
+`clonotypes`, `clonotypeTables` and `qcReportTable` outputs with it.
 
-- RAM is now `clamp(perByte × size(clns), floor, 128 GiB)` — floor/slope 16 GiB
-  and 16 for the bulk export, 32 GiB and 32 for the single-cell export, which
-  pays the per-cell division multiplier.
-- An Advanced Settings memory override is now used as-is rather than being
-  quartered, matching how the analyze step treats the same setting. Projects
-  that set it will request 4× more for the export step than before.
-- The two PTabler steps are no longer sized off the mixcr step's budget; they
-  are left unsized so workflow-tengo 6.8's built-in input-volume formula
-  applies, as it already does for the rest of the single-cell pipeline.
+- RAM is now `clamp(perByte × size(clns), floor, 128 GiB)` — 16 GiB and 16× for the
+  bulk export, 32 GiB and 32× for the single-cell export, which pays the per-cell
+  expansion.
+- An Advanced Settings memory override now applies as-is rather than quartered,
+  matching how the analyze step treats the same setting. Projects that set it will
+  request 4× more for the export step than before.
+- The two PTabler steps now inherit workflow-tengo 6.8's built-in input-volume
+  formula, as the rest of the single-cell pipeline already does. They previously took
+  ⅔ of the mixcr step's budget.

--- a/.changeset/export-clones-memory.md
+++ b/.changeset/export-clones-memory.md
@@ -18,8 +18,10 @@ sample exhausted it: `exportClones` died with `OutOfMemoryError`, taking the
 `clonotypes`, `clonotypeTables` and `qcReportTable` outputs with it.
 
 - RAM is now `clamp(perByte × size(clns), floor, 128 GiB)` — 16 GiB and 16× for the
-  bulk export, 32 GiB and 32× for the single-cell export, which pays the per-cell
-  expansion.
+  bulk export, 24 GiB and 32× for the single-cell export, which pays the per-cell
+  expansion. 24 GiB yields 20889 MiB of heap, 2.4× the ceiling that failed. The floors
+  are kept tight because `-Xms` is half the grant: the request is a hard pre-allocation,
+  and a sample runs one bulk plus one single-cell export per chain group.
 - An Advanced Settings memory override now applies as-is rather than quartered,
   matching how the analyze step treats the same setting. Projects that set it will
   request 4× more for the export step than before.

--- a/workflow/src/mixcr-export.tpl.tengo
+++ b/workflow/src/mixcr-export.tpl.tengo
@@ -58,7 +58,7 @@ self.body(func(inputs) {
 	//
 	// A flat 12 GiB failed on a 10.7k-cell / 26.7k-clone 10x BCR sample. The mixcr
 	// entrypoint turns a container grant R into
-	//     -Xmx = max(min(0.85*R, R - 3500 MiB), 0.5*R)
+	//     -Xmx = max(min(0.85*R, R - 3500 MiB), 0.5*R)   and   -Xms = 0.5*R
 	// so the flat non-heap reserve costs small grants disproportionately: 12 GiB yields
 	// 8788 MiB of heap, which OOM'd.
 	//
@@ -69,6 +69,12 @@ self.body(func(inputs) {
 	// blob size via getBlobSize -- metadata only, no pre-exec. An Advanced Settings
 	// override replaces the formula outright, matching the analyze step; where a backend
 	// cannot evaluate formulas, the static fallback is the floor.
+	//
+	// Keep the floors tight. -Xms is half the grant, so the request is a hard
+	// pre-allocation, not just a ceiling -- and a sample runs one bulk plus one
+	// single-cell export per chain group, so the floors are paid several times over
+	// concurrently. An over-estimate here does not merely waste the reservation, it
+	// pre-touches it. 24 GiB yields 20889 MiB of heap, 2.4x the ceiling that failed.
 	formula := exec.formula
 	exportRamCapGiB := 128
 	exportRam := func(floorGiB, perByte) {
@@ -218,7 +224,7 @@ self.body(func(inputs) {
 					mixcrCmdBuilder.arg(arg)
 				}
 			}
-		}, exportRam(32, 32))
+		}, exportRam(24, 32))
 
 		unprocessedTsvForSingleCell := mixcrForSingleCell.getFile("clones.tsv")
 

--- a/workflow/src/mixcr-export.tpl.tengo
+++ b/workflow/src/mixcr-export.tpl.tengo
@@ -7,7 +7,6 @@ smart := import("@platforma-sdk/workflow-tengo:smart")
 slices := import("@platforma-sdk/workflow-tengo:slices")
 assets := import("@platforma-sdk/workflow-tengo:assets")
 exec := import("@platforma-sdk/workflow-tengo:exec")
-units := import("@platforma-sdk/workflow-tengo:units")
 pt := import("@platforma-sdk/workflow-tengo:pt")
 clonotypeLabel := import(":clonotype-label")
 stopCodonReplacement := import(":stop-codon-replacement")
@@ -50,16 +49,40 @@ self.body(func(inputs) {
 
 	useProductiveFilter := is_undefined(stopCodonTypes) || len(stopCodonTypes) == 0
 
-	exportMemGB := undefined
-	if !is_undefined(inputs.perProcessMemGB) {
-		exportMemGB = int(1.0*inputs.perProcessMemGB/4.0)
-		if exportMemGB < 12 {
-			exportMemGB = 12
+	// Memory for the `exportClones` execs.
+	//
+	// exportClones has no streaming path: it reads the whole CloneSet into heap, and
+	// for single-cell exports it then materialises a SECOND, expanded list via
+	// divideClonesByTags -- one clone per (clonotype x cell), each carrying its own
+	// split TagCount -- which is sorted and re-ranked before writing. The --chains
+	// filter is applied only after that division, so exporting one chain group still
+	// pays the whole-file cost. Peak therefore tracks what is inside the .clns, not a
+	// constant, and the single-cell path costs several times the bulk path.
+	//
+	// Sizing this at a flat 12 GiB is what made a 10.7k-cell / 26.7k-clone 10x BCR
+	// sample fail: the mixcr entrypoint turns a container grant R into
+	// -Xmx = max(min(0.85*R, R - 3500 MiB), 0.5*R), so a small grant loses a
+	// disproportionate share to the flat non-heap reserve -- R = 12 GiB left only
+	// 8788 MiB of heap, and exportClones died with OutOfMemoryError.
+	//
+	//     ram = clamp(perByte * size(clns), floor, 128 GiB)
+	//
+	// The floor carries small inputs, where the in-heap tag-count object graph rather
+	// than the stored file dominates; the linear term carries large ones. size("clns")
+	// sums the stored blob size via getBlobSize -- a metadata read, no pre-exec.
+	// An "Advanced Settings" memory override replaces the formula outright (same
+	// semantics as the analyze step); on backends that cannot evaluate resource
+	// formulas, the static fallback is the floor.
+	formula := exec.formula
+	exportRamCapGiB := 128
+	exportRam := func(floorGiB, perByte) {
+		if !is_undefined(inputs.perProcessMemGB) {
+			return string(inputs.perProcessMemGB) + "GiB"
 		}
-	} else {
-		exportMemGB = 12
+		return formula.size("clns").times(perByte).
+			between(formula.gib(floorGiB), formula.gib(exportRamCapGiB)).
+			staticFallback(formula.gib(floorGiB))
 	}
-	ptMemGB := int(2.0*exportMemGB/3.0)
 
 	hashKeyDerivationExpressionPt := func(sourceColumns) {
 		return pt.concatStr(
@@ -70,11 +93,10 @@ self.body(func(inputs) {
 
 	// Exporting clones from clns file
 
-	createExport := func(additionalAction) {
+	createExport := func(additionalAction, ramRequest) {
 		mixcrCmdBuilder := exec.builder().
 			inMediumQueue().
-			mem(string(exportMemGB) + "GiB").
-		    cpu(2).
+			resources({ onCPU: { cpu: 2, ram: ramRequest } }).
 			env("MI_USE_SYSTEM_CA", "true").
 			software(mixcrSw).
 			secret("MI_LICENSE", "MI_LICENSE").
@@ -102,20 +124,21 @@ self.body(func(inputs) {
 
 		return mixcrCmdBuilder.
 			arg("clones.clns").
-			addFile("clones.clns", clnsFile).
+			addFile("clones.clns", clnsFile, { tag: "clns" }).
 			arg("clones.tsv").
 			saveFile("clones.tsv").
 			cacheHours(3).
 			run()
 	}
 
+	// Bulk export: whole CloneSet resident, no per-cell division.
 	mixcrCmd := createExport(func(mixcrCmdBuilder) {
 		for argGrp in exportArgs {
 			for arg in argGrp {
 				mixcrCmdBuilder.arg(arg)
 			}
 		}
-	})
+	}, exportRam(16, 16))
 
 	unprocessedTsv := mixcrCmd.getFile("clones.tsv")
 
@@ -127,11 +150,13 @@ self.body(func(inputs) {
 		ll.panic("clonotypeKeyColumns is undefined")
 	}
 
-	// PTabler processing for main TSV output
+	// PTabler processing for main TSV output.
+	// Left unsized on purpose: workflow-tengo 6.8 sizes an unsized pt.workflow() from
+	// its own input volume (ram = clamp(2 GiB + 4 * size, 2 GiB, 64 GiB)), which tracks
+	// the exported TSV far better than a fixed share of the mixcr step's budget. An
+	// explicit .mem()/.cpu() here would suppress that.
 	wfMain := pt.workflow().
-		inMediumQueue().
-		mem(ptMemGB * units.GiB).
-		cpu(2)
+		inMediumQueue()
 
 	frameInputMap := {
 		file: unprocessedTsv,
@@ -181,6 +206,8 @@ self.body(func(inputs) {
 	result.tsv = processedTsv
 
 	if !is_undefined(cellTagColumns) {
+		// Single-cell export: pays the divideClonesByTags multiplier on top of the
+		// resident CloneSet, so it gets a higher floor and a steeper slope than bulk.
 		mixcrForSingleCell := createExport(func(mixcrCmdBuilder) {
 			mixcrCmdBuilder.
 				arg("--split-by-tags").arg("Cell").
@@ -196,15 +223,13 @@ self.body(func(inputs) {
 					mixcrCmdBuilder.arg(arg)
 				}
 			}
-		})
+		}, exportRam(32, 32))
 
 		unprocessedTsvForSingleCell := mixcrForSingleCell.getFile("clones.tsv")
 
-		// PTabler processing for single-cell TSV output
+		// PTabler processing for single-cell TSV output (unsized -- see wfMain above).
 		wfSingleCell := pt.workflow().
-			inMediumQueue().
-			mem(ptMemGB * units.GiB).
-			cpu(2)
+			inMediumQueue()
 
 		frameLoadOps := {
 			xsvType: "tsv",

--- a/workflow/src/mixcr-export.tpl.tengo
+++ b/workflow/src/mixcr-export.tpl.tengo
@@ -49,30 +49,26 @@ self.body(func(inputs) {
 
 	useProductiveFilter := is_undefined(stopCodonTypes) || len(stopCodonTypes) == 0
 
-	// Memory for the `exportClones` execs.
+	// Size both `exportClones` execs from the .clns. A constant cannot work here:
+	// exportClones loads the whole CloneSet into heap, and single-cell exports then
+	// materialise a SECOND, expanded list via divideClonesByTags -- one clone per
+	// (clonotype x cell), each with its own split TagCount -- then sort and re-rank it.
+	// --chains filters only after that expansion, so exporting one chain group still
+	// pays the whole-file cost. Single-cell therefore costs several times bulk.
 	//
-	// exportClones has no streaming path: it reads the whole CloneSet into heap, and
-	// for single-cell exports it then materialises a SECOND, expanded list via
-	// divideClonesByTags -- one clone per (clonotype x cell), each carrying its own
-	// split TagCount -- which is sorted and re-ranked before writing. The --chains
-	// filter is applied only after that division, so exporting one chain group still
-	// pays the whole-file cost. Peak therefore tracks what is inside the .clns, not a
-	// constant, and the single-cell path costs several times the bulk path.
-	//
-	// Sizing this at a flat 12 GiB is what made a 10.7k-cell / 26.7k-clone 10x BCR
-	// sample fail: the mixcr entrypoint turns a container grant R into
-	// -Xmx = max(min(0.85*R, R - 3500 MiB), 0.5*R), so a small grant loses a
-	// disproportionate share to the flat non-heap reserve -- R = 12 GiB left only
-	// 8788 MiB of heap, and exportClones died with OutOfMemoryError.
+	// A flat 12 GiB failed on a 10.7k-cell / 26.7k-clone 10x BCR sample. The mixcr
+	// entrypoint turns a container grant R into
+	//     -Xmx = max(min(0.85*R, R - 3500 MiB), 0.5*R)
+	// so the flat non-heap reserve costs small grants disproportionately: 12 GiB yields
+	// 8788 MiB of heap, which OOM'd.
 	//
 	//     ram = clamp(perByte * size(clns), floor, 128 GiB)
 	//
-	// The floor carries small inputs, where the in-heap tag-count object graph rather
-	// than the stored file dominates; the linear term carries large ones. size("clns")
-	// sums the stored blob size via getBlobSize -- a metadata read, no pre-exec.
-	// An "Advanced Settings" memory override replaces the formula outright (same
-	// semantics as the analyze step); on backends that cannot evaluate resource
-	// formulas, the static fallback is the floor.
+	// The floor carries small inputs, where the in-heap tag-count graph rather than the
+	// stored file dominates; the linear term carries large ones. size("clns") reads the
+	// blob size via getBlobSize -- metadata only, no pre-exec. An Advanced Settings
+	// override replaces the formula outright, matching the analyze step; where a backend
+	// cannot evaluate formulas, the static fallback is the floor.
 	formula := exec.formula
 	exportRamCapGiB := 128
 	exportRam := func(floorGiB, perByte) {
@@ -131,7 +127,7 @@ self.body(func(inputs) {
 			run()
 	}
 
-	// Bulk export: whole CloneSet resident, no per-cell division.
+	// Bulk export: loads the CloneSet and writes it straight out.
 	mixcrCmd := createExport(func(mixcrCmdBuilder) {
 		for argGrp in exportArgs {
 			for arg in argGrp {
@@ -150,11 +146,10 @@ self.body(func(inputs) {
 		ll.panic("clonotypeKeyColumns is undefined")
 	}
 
-	// PTabler processing for main TSV output.
-	// Left unsized on purpose: workflow-tengo 6.8 sizes an unsized pt.workflow() from
-	// its own input volume (ram = clamp(2 GiB + 4 * size, 2 GiB, 64 GiB)), which tracks
-	// the exported TSV far better than a fixed share of the mixcr step's budget. An
-	// explicit .mem()/.cpu() here would suppress that.
+	// PTabler processing for main TSV output. Left unsized so workflow-tengo 6.8 sizes it
+	// from its own input volume (ram = clamp(2 GiB + 4 * size, 2 GiB, 64 GiB)), which
+	// tracks the exported TSV better than a fixed share of the mixcr step's budget. An
+	// explicit .mem()/.cpu() would suppress that.
 	wfMain := pt.workflow().
 		inMediumQueue()
 
@@ -206,8 +201,8 @@ self.body(func(inputs) {
 	result.tsv = processedTsv
 
 	if !is_undefined(cellTagColumns) {
-		// Single-cell export: pays the divideClonesByTags multiplier on top of the
-		// resident CloneSet, so it gets a higher floor and a steeper slope than bulk.
+		// Single-cell export: pays the divideClonesByTags expansion on top of the
+		// resident CloneSet -- hence the higher floor and steeper slope.
 		mixcrForSingleCell := createExport(func(mixcrCmdBuilder) {
 			mixcrCmdBuilder.
 				arg("--split-by-tags").arg("Cell").


### PR DESCRIPTION
Ticket: MILAB-6725 — https://app.notion.com/3b23a83ff4af81d78906f6ff5c9dbd11
Reported in: https://platforma-bio.slack.com/archives/C0B0KCF0VDF/p1785763510195099

## What broke

A customer running 10x single-cell BCR on EKS lost three block outputs at once —
`clonotypes`, `clonotypeTables` and `qcReportTable`. All three are one failure: the
IGK/IGL single-cell `exportClones` died with `OutOfMemoryError` (exit 2), and all three
depend on its `tsvForSingleCell`.

The failing command, verbatim from the report:

```
java -Xmx8788m -Xms6144m ... exportClones --dont-split-files --drop-default-fields \
  --reset-export-clone-table-splitting --chains IGK,IGL --export-productive-clones-only \
  --split-by-tags Cell -tags Cell -nFeature VDJRegion -vGene -jGene \
  -isProductive VDJRegionInFrame -uniqueTagCount Molecule clones.clns clones.tsv
```

The chain:

1. `mixcr-export.tpl.tengo` sized the export exec at a flat **12 GiB**
   (`max(12, perProcessMemGB / 4)`).
2. The `memory-from-limits` entrypoint turns a container grant `R` into
   `-Xmx = max(min(0.85·R, R − 3500 MiB), 0.5·R)`. At `R` = 12288 MiB that gives
   **`-Xmx8788m`**, matching the observed command line exactly. The flat 3500 MiB
   reserve dominates until `R` ≈ 23 GiB, so small grants lose a disproportionate share
   to non-heap.
3. `exportClones` loads the whole `CloneSet` into heap (`CommandExportClones.kt:238`).
   Single-cell exports then call `divideClonesByTags` (`:308`), which materialises a
   **second, expanded list** — one clone per (clonotype × cell), each with its own split
   `TagCount` — then sorts and re-ranks it (`mixcr-algo` `CloneSet.kt:146-150`).
4. `--chains` filters only after that division (`:348`), so exporting one chain group
   still pays the whole-file cost. This block loops chain groups and runs bulk plus
   single-cell per group: four of these per two-chain-group BCR sample.
5. Heap exhausted → `Main.kt:107` catches `OutOfMemoryError` → exit 2.

MiXCR's message misleads. *"This run used approximately 8792m of memory, this machine
has 12288 Mb in total"* reads as "used 8.6 of 12, plenty spare", but `8792m` is
`Runtime.getRuntime().maxMemory()` — the heap **ceiling**, not usage.

**The dataset was small** — 26,744 clones, ~10.7k cell barcodes. The 12 GiB was never
connected to anything. The same block sizes `analyze` at
`clamp(192 GiB + 4·size(reads), 192 GiB, 256 GiB)` for this preset — a 16× gap against
a step that holds an expanded copy of the clone set.

This is the second incident on this container. `83c4eb99` in the mixcr repo raised the
entrypoint's non-heap reserve 2500 → 3500 MiB because *"Export commands on 12 GiB
containers were getting OOM-killed"*. That fixed a container kill by lowering `-Xmx`,
which set up today's heap OOM.

## The change

Both export execs now derive RAM from the `.clns`:

```
ram = clamp(perByte × size(clns), floor, 128 GiB)
```

| Export | floor | perByte | why |
|---|---|---|---|
| bulk | 16 GiB | 16 | loads the CloneSet and writes it out |
| single-cell | 24 GiB | 32 | additionally pays the `divideClonesByTags` expansion |

`size()` sums the stored blob size via `getBlobSize` — a metadata read, no pre-exec
pass. The floor carries small inputs, where the in-heap tag-count graph rather than the
stored file dominates; the linear term carries large ones. A 24 GiB grant yields
20889 MiB of heap, 2.4× the ceiling that failed.

The floors are deliberately tight. `-Xms` is half the grant, so a request is a hard
pre-allocation rather than just a ceiling, and a sample runs one bulk plus one
single-cell export per chain group — the floors are paid several times over
concurrently. A separate incident this week had a `mixcr analyze` step granted 484 GiB,
pre-touch 242 GiB at JVM start, and get OOM-killed before finishing. Over-estimating a
request is not free.

`between()` supplies the floor rather than `.plus(gib(floor))`. The additive form
double-counts: the floors are total-memory values, so adding them to a size-proportional
term charges for the data twice.

Two changes follow from it:

- **The Advanced Settings memory override now applies as-is.** `perProcessMemGB` reaches
  the export exec unquartered, matching `mixcr-analyze.tpl.tengo`. Previously a user
  setting 48 GiB got 12 GiB here, so the documented escape hatch barely moved the failing
  step. **Projects that set it will request 4× more for the export step than before** —
  the one behaviour change worth pushing back on.
- **The two PTabler steps now inherit workflow-tengo 6.8's input-volume formula**
  (`ram = clamp(2 GiB + 4·size, 2 GiB, 64 GiB)`), which tracks the exported TSV better
  than a fixed share of a sibling step's budget. They previously took ⅔ of
  `exportMemGB`, which cannot survive that value becoming a formula. #204 gave the rest
  of the single-cell pipeline the same treatment; an explicit `.mem()`/`.cpu()` here was
  suppressing it.

The template's `hash_override` stays as-is. Resource requests ride as CID-transparent
meta inputs so a re-run with more memory reuses everything else, and the failed step
re-runs regardless — a failure is not a cached success.

## Verified

Live, on a local backend, running the block's own `simple sc project` test — same
`10x-sc-xcr-vdj` preset and the same IGH + IGK,IGL chain groups as the customer:

- Test green. The per-block log shows the export execs receiving **`-Xmx12884m`** (bulk,
  16 GiB grant) and **`-Xmx27852m`** (single-cell, at the 32 GiB floor this ran under),
  both matching the entrypoint arithmetic exactly. Before the fix all eight were
  `-Xmx8788m`. This proves `formula.size("clns")` resolves at run time — an unmatched tag
  would have hard-failed the template — and that bulk and single-cell get different
  grants. The floor has since been lowered to 24 GiB; the mechanism is unchanged.
- `analyze` was observed requesting 192 GiB and receiving `-Xmx33934m` — the silent
  bucket clamp, live.
- **The failure signature reproduces.** Running the customer's exact `exportClones`
  argument list directly against a real single-cell `.clns` below ~64 MiB of heap gives
  `Not enough memory for run command` and **exit 2** — the reported signature. The
  failure is heap-bound and this is the controlling knob.
- **Resource changes are CID-transparent**, confirmed the hard way: bumping the grant,
  changing the template hash, adding a distinguishing env var and rebuilding the block
  pack all failed to invalidate the cached exec. Worth knowing before anyone tries to
  bisect memory through the UI.
- `pnpm run build:dev-local` — 9/9 tasks green.
- `size` accepts `.clns`: `_assertMetricCompatible` in `formula.lib.tengo` restricts only
  `lineCount` to line-oriented text formats.
- The compute bucket clamps over-large requests (`bucket.go:199-204` / `:301-307`) and
  feeds the clamped value to `{system.ram.mib}` rendering, so the JVM gets a consistent
  `-Xmx`. Raising the floor cannot strand a desktop user with an unschedulable request.

## Not verified

- **The slopes (16 / 32) are estimates** — and now measurably so. Sweeping minimum
  passing heap across two real `.clns` files (86 KB and 1.24 MB, a 14× range) gave
  **64 MiB for both bulk and single-cell on both inputs**. At that scale heap is entirely
  JVM plus reference-library overhead; the data contributes nothing measurable. The
  largest `.clns` available locally holds 345 clone×cell pairs against the customer's
  tens of thousands, so **no local dataset can calibrate the slope or discriminate bulk
  from single-cell.** That is a measurement, not an assumption.
- The 24 GiB floor has not itself been run live; the live run above used 32 GiB. The
  mechanism is identical.
- The customer's own data has not been run.

The `.clns` from the failed run — or just its size — would turn the coefficient into a
measurement. It is derived data, not raw sequence. A calibration plan against the
studies library is drafted separately.

## How to verify locally

The bug is "grant too small for the data", which is two independent claims. The mechanism
is testable today; the sufficiency of these specific numbers needs larger data.

1. **Force the failure, then clear it.** Scale the grant down rather than the data up.
   Pin the export to `mem("1GiB")` (→ `-Xmx512m`) and run the single-cell fixture in
   `test/assets`: expect the same `Not enough memory for run command` / exit 2 signature
   and the same error chain through `tsvForSingleCell`. Restore the formula and it
   passes. Proves the failure is heap-bound and that this is the controlling knob.
2. **Read back the allocated grant.** Start the backend with `--log-blocks-enabled` and
   grep the per-block log for the `java -Xmx…` line. Before: `-Xmx8788m`. After: the
   24 GiB request, clamped by the medium bucket to whatever the host allows. This is also
   the only check that proves `formula.size("clns")` resolves at run time.
3. **Bisect `-Xmx`** against a fixture `.clns` for a measured heap-per-clns-byte ratio.
   Treat it as a lower bound — tag-count overhead does not scale linearly from a 1.2 MB
   fixture to a real sample.

## Follow-up

The same flat-12-GiB export sizing exists in `mixcr-shm-trees` (12 GiB on the **light**
queue, the worst of the set), `miltenyi-tcr-bcr-clonotyping` (also single-cell, same
multiplier) and `mixcr-amplicon-alignment`. Staged so this one can be confirmed against
the customer first.

## Interim workaround

Set **Advanced Settings → memory per process = 192 GB**. On the current release that
gives the export 48 GiB (~41 GiB heap). Use 192 specifically: the override also replaces
`analyze`'s formula, and 192 GiB is the floor `analyze` already computes for MiTool
presets, so nothing regresses.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR replaces fixed `exportClones` memory grants with bounded formulas based on `.clns` blob size, preserves direct Advanced Settings overrides, and delegates PTabler sizing to workflow-tengo 6.8.2 defaults.
- **`exportClones`**: MiXCR command that loads a CloneSet and emits clone tables; its bulk and single-cell executions now receive separate size-based RAM formulas.
- **`.clns`**: Stored MiXCR CloneSet artifact; it is tagged as `clns` so its blob size can drive runtime resource calculation.
- **`CloneSet`**: In-memory collection of clones loaded by `exportClones`; the new bulk formula uses a 16 GiB floor, a 16× stored-size multiplier, and a 128 GiB cap.
- **`divideClonesByTags`**: Single-cell expansion that creates clone-per-cell representations; the corresponding export uses a 24 GiB floor and a 32× multiplier.
- **`perProcessMemGB`**: Advanced Settings memory override; it now applies directly to export executions instead of being divided by four.
- **PTabler**: TSV-processing workflow used after export; explicit CPU and RAM settings were removed so workflow-tengo can derive resources from input volume.
- Adds a patch changeset documenting the incident, sizing model, override behavior, and PTabler resource change.

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge, with no blocking failure remaining in the eligible follow-up-review scope.

No blocking failure remains.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| workflow/src/mixcr-export.tpl.tengo | Replaces fixed export and PTabler resource assignments with tagged-input formulas, distinct bulk and single-cell bounds, direct overrides, and workflow defaults. |
| .changeset/export-clones-memory.md | Documents the export heap failure, the new resource-sizing formulas, override semantics, and PTabler sizing behavior. |

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[.clns blob] --> B[Tagged input: clns]
    B --> C{Export mode}
    C -->|Bulk| D[RAM: clamp 16x size, 16 GiB, 128 GiB]
    C -->|Single-cell| E[RAM: clamp 32x size, 24 GiB, 128 GiB]
    F[perProcessMemGB override] -->|When configured| D
    F -->|When configured| E
    D --> G[exportClones]
    E --> H[exportClones plus tag expansion]
    G --> I[Exported TSV]
    H --> J[Single-cell TSV]
    I --> K[PTabler default input-volume sizing]
    J --> L[PTabler default input-volume sizing]
```
</details>

<sub>Reviews (3): Last reviewed commit: ["fix: lower the single-cell export floor ..."](https://github.com/platforma-open/mixcr-clonotyping/commit/9b6d7725e4dac8028f7bd49c14dfeafdf3a2ed69) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=49991264)</sub>

<!-- /greptile_comment -->