### PR TITLE
[test] req-bump 1: no changeset, no label (expect check RED)

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -13,14 +13,14 @@ jobs:
   init:
     runs-on: hz-ubuntu-dind
     steps:
-      - uses: milaboratory/github-ci/actions/context/init@v4
+      - uses: milaboratory/github-ci/actions/context/init@v4-beta
         with:
           version-canonize: false
           branch-versioning: main
   run:
     needs:
       - init
-    uses: milaboratory/github-ci/.github/workflows/node-simple-pnpm.yaml@v4
+    uses: milaboratory/github-ci/.github/workflows/node-simple-pnpm.yaml@v4-beta
     with:
       app-name: 'Block: Mixcr Clonotyping 2'
       app-name-slug: 'block-mixcr-clonotyping-2'
@@ -38,6 +38,7 @@ jobs:
       publish-to-public: 'true'
       package-path: 'block'
       create-tag: 'true'
+      require-package-path-bump: true
 
       npmrc-config: |
         {


### PR DESCRIPTION
Validation PR for MILAB-6707 (github-ci @v4-beta require-package-path-bump gate). Points build.yaml at @v4-beta + enables the toggle. **Do not merge** — checking CI status only.

Expected: `run / check for changesets` **RED**; build/test jobs still run.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This validation PR temporarily moves the build workflow to the `github-ci` v4 beta channel and enables its package-path version-bump gate; it is explicitly marked “Do not merge.”
- **Reusable workflow** — A workflow invoked by another workflow; `node-simple-pnpm.yaml` changes from the stable `@v4` reference to `@v4-beta`.
- **Context initialization action** — The action that prepares shared CI context; its reference likewise changes from `@v4` to `@v4-beta`.
- **Package path** — The package directory evaluated by the CI gate; it remains `block`.
- **Package-path bump gate** — Validation requiring modified packages under the configured path to have an associated version bump or changeset; it is enabled with `require-package-path-bump: true`.
- **Changeset check** — The CI check expected to detect the intentionally missing package bump; this PR expects it to report red while build and test jobs continue.

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

No unacknowledged defect was identified, but the PR must not be merged because it is explicitly a temporary CI validation with an intentionally failing check.

The configured boolean input matches the beta reusable workflow contract, and the expected failing changeset check and beta references are deliberate, documented aspects of this validation PR.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/workflows/build.yaml | Deliberately selects the v4 beta CI action and reusable workflow and enables the package-path bump gate for a temporary negative validation run. |

</details>

<sub>Reviews (1): Last reviewed commit: ["test(MILAB-6707): v4-beta gate — no chan..."](https://github.com/platforma-open/mixcr-clonotyping/commit/3d9572e25301156665be526916670ab058f62640) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=49990182)</sub>

<!-- /greptile_comment -->