### PR TITLE
[test] req-bump 2: no changeset + skip-changelog (expect check skipped/pass)

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -13,14 +13,14 @@ jobs:
   init:
     runs-on: hz-ubuntu-dind
     steps:
-      - uses: milaboratory/github-ci/actions/context/init@v4
+      - uses: milaboratory/github-ci/actions/context/init@v4-beta
         with:
           version-canonize: false
           branch-versioning: main
   run:
     needs:
       - init
-    uses: milaboratory/github-ci/.github/workflows/node-simple-pnpm.yaml@v4
+    uses: milaboratory/github-ci/.github/workflows/node-simple-pnpm.yaml@v4-beta
     with:
       app-name: 'Block: Mixcr Clonotyping 2'
       app-name-slug: 'block-mixcr-clonotyping-2'
@@ -38,6 +38,7 @@ jobs:
       publish-to-public: 'true'
       package-path: 'block'
       create-tag: 'true'
+      require-package-path-bump: true
 
       npmrc-config: |
         {


### PR DESCRIPTION
Validation PR for MILAB-6707 (github-ci @v4-beta require-package-path-bump gate). Points build.yaml at @v4-beta + enables the toggle. **Do not merge** — checking CI status only.

Expected: `run / check for changesets` **skipped** (== passing) due to the `skip-changelog` label.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This validation-only PR switches the build workflow to the `github-ci` v4 beta revision and enables its package-path version-bump gate to verify that the `skip-changelog` label skips the changeset check.

- **`v4-beta`** — The beta branch of the shared `milaboratory/github-ci` actions and reusable workflows. Both CI references change from the stable `v4` branch to this beta branch for the validation.
- **`require-package-path-bump`** — A reusable-workflow boolean input requiring the package selected by `package-path` to include the expected version bump. It is newly enabled.
- **`package-path`** — The directory containing the package evaluated by the gate. It remains `block`, targeting the block package metadata.
- **`skip-changelog`** — A pull-request label expected to bypass the changeset/changelog check. This PR validates that the resulting check is skipped and therefore treated as passing.

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

No unacknowledged defect was identified in this validation-only workflow change, though the PR description explicitly says it must not be merged.

The workflow changes are consistent with the stated CI experiment, and the potentially persistent beta configuration is already explicitly acknowledged and excluded from merge.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/workflows/build.yaml | Temporarily selects the shared CI beta branch and enables its package-path-bump gate; no unacknowledged actionable defect was established. |

</details>

<sub>Reviews (1): Last reviewed commit: ["test(MILAB-6707): v4-beta gate — skip-ch..."](https://github.com/platforma-open/mixcr-clonotyping/commit/978095627d756e67ff6f0e1784f51c82fe6c2969) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=49990191)</sub>

**Context used:**

- Context used - Terms is a types in codebase. Provide the list of ... ([source](https://app.greptile.com/review/custom-context?memory=instruction-0))

<!-- /greptile_comment -->