### PR TITLE
[test] req-bump 3: empty changeset (expect check green)

### DIFF
--- a/.changeset/empty-cs.md
+++ b/.changeset/empty-cs.md
@@ -1,0 +1,4 @@
+---
+---
+
+test changeset

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -13,14 +13,14 @@ jobs:
   init:
     runs-on: hz-ubuntu-dind
     steps:
-      - uses: milaboratory/github-ci/actions/context/init@v4
+      - uses: milaboratory/github-ci/actions/context/init@v4-beta
         with:
           version-canonize: false
           branch-versioning: main
   run:
     needs:
       - init
-    uses: milaboratory/github-ci/.github/workflows/node-simple-pnpm.yaml@v4
+    uses: milaboratory/github-ci/.github/workflows/node-simple-pnpm.yaml@v4-beta
     with:
       app-name: 'Block: Mixcr Clonotyping 2'
       app-name-slug: 'block-mixcr-clonotyping-2'
@@ -38,6 +38,7 @@ jobs:
       publish-to-public: 'true'
       package-path: 'block'
       create-tag: 'true'
+      require-package-path-bump: true
 
       npmrc-config: |
         {


### PR DESCRIPTION
Validation PR for MILAB-6707 (github-ci @v4-beta require-package-path-bump gate). Points build.yaml at @v4-beta + enables the toggle. **Do not merge** — checking CI status only.

Expected: `run / check for changesets` **green** — an empty changeset waives the bump.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This validation-only PR moves the build workflow to `github-ci` v4-beta, enables its package-path bump gate, and adds an empty changeset to test the gate’s waiver behavior.
- **`v4-beta`** — the prerelease reference for the shared `milaboratory/github-ci` action and reusable workflow; both build workflow references move from `v4` to `v4-beta`.
- **`require-package-path-bump`** — a reusable-workflow input requiring package changes to be represented by an appropriate package bump; it is newly enabled.
- **Empty changeset** — a valid Changesets record with no package release entries; `.changeset/empty-cs.md` is added to exercise the intended no-bump waiver.
- **Package path** — the workspace area evaluated by the shared workflow for bump coverage; it remains configured as `block`.

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

No actionable defect was identified for this intentionally temporary CI-validation PR, though the author explicitly states that it must not be merged.

The empty changeset matches the supported package-less Changesets format, and the workflow changes consistently select the beta implementation required to exercise the new package-path bump gate.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/workflows/build.yaml | Switches both shared CI references to the intentionally tested beta channel and enables the package-path bump requirement; no unacknowledged defect was established. |
| .changeset/empty-cs.md | Adds a syntactically valid empty changeset whose lack of package releases matches the stated CI-waiver test. |

</details>

<sub>Reviews (1): Last reviewed commit: ["test(MILAB-6707): v4-beta gate — empty c..."](https://github.com/platforma-open/mixcr-clonotyping/commit/a80d3df96fda72b46b5768bf9b17bac54ad5bff6) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=49990199)</sub>

<!-- /greptile_comment -->