### PR TITLE
[test] req-bump 4: direct block bump (expect check green)

### DIFF
--- a/.changeset/direct-bump.md
+++ b/.changeset/direct-bump.md
@@ -1,0 +1,5 @@
+---
+"@platforma-open/milaboratories.mixcr-clonotyping-2": patch
+---
+
+test changeset

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -13,14 +13,14 @@ jobs:
   init:
     runs-on: hz-ubuntu-dind
     steps:
-      - uses: milaboratory/github-ci/actions/context/init@v4
+      - uses: milaboratory/github-ci/actions/context/init@v4-beta
         with:
           version-canonize: false
           branch-versioning: main
   run:
     needs:
       - init
-    uses: milaboratory/github-ci/.github/workflows/node-simple-pnpm.yaml@v4
+    uses: milaboratory/github-ci/.github/workflows/node-simple-pnpm.yaml@v4-beta
     with:
       app-name: 'Block: Mixcr Clonotyping 2'
       app-name-slug: 'block-mixcr-clonotyping-2'
@@ -38,6 +38,7 @@ jobs:
       publish-to-public: 'true'
       package-path: 'block'
       create-tag: 'true'
+      require-package-path-bump: true
 
       npmrc-config: |
         {


### PR DESCRIPTION
Validation PR for MILAB-6707 (github-ci @v4-beta require-package-path-bump gate). Points build.yaml at @v4-beta + enables the toggle. **Do not merge** — checking CI status only.

Expected: `run / check for changesets` **green** — the block package is bumped directly.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This validation PR switches the build pipeline to the `github-ci` v4 beta, enables direct package-path bump enforcement, and supplies the expected block changeset. Important touched terms:
- **Changeset** — release metadata identifying packages and semantic-version increments; a patch bump is added for `@platforma-open/milaboratories.mixcr-clonotyping-2`.
- **Package path** — the workspace directory whose package must be represented by a version bump; it remains `block`.
- **Direct package bump gate** — CI validation requiring a changeset for the package resolved from `package-path`; it is enabled through `require-package-path-bump: true`.
- **Reusable workflow** — a centrally maintained GitHub Actions workflow invoked by this repository; its revision changes from `v4` to `v4-beta`.
- **Context initialization action** — the shared action that prepares CI context and versioning information; its revision also changes from `v4` to `v4-beta`.

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The changes appear internally consistent for the stated CI validation purpose, although the PR description explicitly says not to merge this test PR.

The changeset targets the package under the configured `block` path, and the new gate is passed to the beta reusable workflow selected to test that feature; no concrete changed-code failure is established.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .changeset/direct-bump.md | Adds a valid patch changeset whose package identifier matches the package located under `block`. |
| .github/workflows/build.yaml | Selects the beta shared CI action and workflow and enables enforcement that the configured block package receives a direct bump. |

</details>

<sub>Reviews (1): Last reviewed commit: ["test(MILAB-6707): v4-beta gate — direct ..."](https://github.com/platforma-open/mixcr-clonotyping/commit/249e11b08573df2450f19ac64cedd21490208ef3) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=49990204)</sub>

<!-- /greptile_comment -->